### PR TITLE
fix: adjust h1 margin in dark theme to match default theme

### DIFF
--- a/src/static/styles/dark.css
+++ b/src/static/styles/dark.css
@@ -8,7 +8,7 @@ body {
 }
 /* Board Name */
 h1 {
-  margin: 0.2em 2% 0.3em 2%;
+  margin: 0.5em 2% 0.3em 2%;
   padding: 0;
   font-size: 2em;
   font-weight: bold;


### PR DESCRIPTION
## Summary
Ajustada a margem do título `h1` no arquivo de estilos `dark.css` para se alinhar com o `margin` padrão () do `default.css`, antes usava incorretamente `0.2em`, causando desalinhamento do topo com as outras variações.