### PR TITLE
feat: add commit hash and GitHub link to page footers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ COPY ./roswell roswell
 
 ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION
+ARG APP_COMMIT_HASH
+ENV APP_COMMIT_HASH=$APP_COMMIT_HASH
 ENV SBBS_DATADIR=/cl-bbs/data/
 ENV SBBS_STATIC_DIR=/cl-bbs/src/static/
 ENV SBBS_INDEX_FILE=/cl-bbs/src/static/index.html

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,10 @@ install-deps:
 server:
 	./roswell/cl-bbs-server.ros
 
-docker-build:
-	docker build --build-arg APP_VERSION=$(APP_VERSION) -t $(DOCKER_IMG) .
+docker-build: dockerbuild
+
+dockerbuild:
+	docker build --build-arg APP_VERSION=$(APP_VERSION) --build-arg APP_COMMIT_HASH=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown") -t $(DOCKER_IMG) .
 
 docker-shell: docker-build
 	docker run --rm -it --entrypoint=/bin/bash $(DOCKER_IMG)

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -20,26 +20,22 @@
   (let ((env-hash (uiop:getenv "APP_COMMIT_HASH")))
     (if (and env-hash (string/= env-hash ""))
         env-hash
-        (or (ignore-errors
-             (string-trim '(#\Space #\Tab #\Newline #\Return)
-                          (uiop:run-program '("git" "rev-parse" "--short" "HEAD")
-                                            :output :string)))
+        (or (handler-case
+                (string-trim '(#\Space #\Tab #\Newline #\Return)
+                             (uiop:run-program '("git" "rev-parse" "--short" "HEAD")
+                                               :output :string))
+              (error () nil))
             "unknown"))))
 
 (defun render-footer-html ()
-  "Renders the common footer HTML with SchemeBBS port attribution, git commit hash, and a GitHub link."
+  "Renders the common footer HTML with cl-bbs version hash and a GitHub link."
   (let ((hash (get-git-commit-hash)))
     (cl-who:with-html-output-to-string (s nil :indent t)
       (:p :class "footer"
-          "SchemeBBS Common Lisp port ("
+          "cl-bbs version:"
           (:a :href (format nil "https://github.com/ryukinix/cl-bbs/commit/~a" hash)
               :target "_blank"
-              (cl-who:fmt "commit ~a" hash))
-          " | "
-          (:a :href "https://github.com/ryukinix/cl-bbs"
-              :target "_blank"
-              "GitHub")
-          ")"))))
+              (cl-who:esc hash))))))
 
 (defun get-hash-hue (id-val)
   (let ((id-num (cond ((integerp id-val) id-val)

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -15,6 +15,32 @@
 
 (in-package :cl-bbs/views)
 
+(defun get-git-commit-hash ()
+  "Gets the git commit hash from environmental dynamics (APP_COMMIT_HASH) with a fallback to uiop:run-program."
+  (let ((env-hash (uiop:getenv "APP_COMMIT_HASH")))
+    (if (and env-hash (string/= env-hash ""))
+        env-hash
+        (or (ignore-errors
+             (string-trim '(#\Space #\Tab #\Newline #\Return)
+                          (uiop:run-program '("git" "rev-parse" "--short" "HEAD")
+                                            :output :string)))
+            "unknown"))))
+
+(defun render-footer-html ()
+  "Renders the common footer HTML with SchemeBBS port attribution, git commit hash, and a GitHub link."
+  (let ((hash (get-git-commit-hash)))
+    (cl-who:with-html-output-to-string (s nil :indent t)
+      (:p :class "footer"
+          "SchemeBBS Common Lisp port ("
+          (:a :href (format nil "https://github.com/ryukinix/cl-bbs/commit/~a" hash)
+              :target "_blank"
+              (cl-who:fmt "commit ~a" hash))
+          " | "
+          (:a :href "https://github.com/ryukinix/cl-bbs"
+              :target "_blank"
+              "GitHub")
+          ")"))))
+
 (defun get-hash-hue (id-val)
   (let ((id-num (cond ((integerp id-val) id-val)
                       ((stringp id-val) (or (handler-case (parse-integer id-val :junk-allowed t)
@@ -75,7 +101,7 @@ function validatePostForm(form, errorId) {
             (:p "We were unable to process your post because it does not meet the validation requirements.")
             (:p (:button :class "error-back-button" :onclick "history.back();" "← Go Back and Edit Post")))
       (:hr)
-      (:p :class "footer" "SchemeBBS Common Lisp port"))))
+      (cl-who:str (render-footer-html)))))
 
 (defun render-boards-header ()
   (let* ((sexp-dir (merge-pathnames "sexp/" cl-bbs/storage:*base-dir*))
@@ -333,7 +359,7 @@ and the new thread form, using layout THEME."
             do (cl-who:htm (cl-who:str (render-frontpage-thread board t-data i theme))))
       (cl-who:str (render-thread-form board))
       (:hr)
-      (:p :class "footer" "SchemeBBS Common Lisp port"))))
+      (cl-who:str (render-footer-html)))))
 
 (defun render-list (board threads &optional theme)
   "Renders the board thread-list HTML page, showing all THREADS in tabular format, using layout THEME."
@@ -358,7 +384,7 @@ and the new thread form, using layout THEME."
                                 (:td (cl-who:str (format nil "~a" messages)))
                                 (:td (:samp (cl-who:esc date)))))))))
       (:hr)
-      (:p :class "footer" "SchemeBBS Common Lisp port"))))
+      (cl-who:str (render-footer-html)))))
 
 (defun render-thread (board thread-id thread-data &optional range-string theme)
   "Renders a single thread page HTML for THREAD-ID under BOARD with THREAD-DATA (comments),
@@ -433,7 +459,7 @@ optionally filtered by RANGE-STRING, using layout THEME."
                   (cl-who:str (format nil "~a" next-post-number))))
          (:dd (cl-who:str (render-post-form board thread-id))))
         (:hr)
-        (:p :class "footer" "SchemeBBS Common Lisp port")))))
+        (cl-who:str (render-footer-html))))))
 
 (defun render-preferences (board &optional theme default-board)
   "Renders the board preferences HTML page, allowing users to choose a custom stylesheet THEME and a default-board."
@@ -484,7 +510,7 @@ function updateThemePreview(themeValue) {
 }
 ")
         (:hr)
-        (:p :class "footer" "SchemeBBS Common Lisp port")))))
+        (cl-who:str (render-footer-html))))))
 
 (defun render-moderation (boards &optional board threads thread comments theme headline)
   "Renders the admin/moderation control panel HTML page showing BOARDS and allowing deletions/edits."

--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -115,7 +115,7 @@
   (let* ((env (list :path-info "/foo" :request-method :get))
          (res (cl-bbs/handlers:handle-request env))
          (html-body (first (third res))))
-    (is equal t (not (null (search "SchemeBBS Common Lisp port (" html-body))))
+    (is equal t (not (null (search "cl-bbs version:" html-body))))
     (is equal t (not (null (search "github.com/ryukinix/cl-bbs" html-body)))))
 
   ;; 1. GET Root /

--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -111,6 +111,13 @@
   ;; Ensure board dirs are created for testing board 'foo'
   (cl-bbs/storage:ensure-board-dirs "foo")
 
+  ;; 0. Test footer renders with commit link
+  (let* ((env (list :path-info "/foo" :request-method :get))
+         (res (cl-bbs/handlers:handle-request env))
+         (html-body (first (third res))))
+    (is equal t (not (null (search "SchemeBBS Common Lisp port (" html-body))))
+    (is equal t (not (null (search "github.com/ryukinix/cl-bbs" html-body)))))
+
   ;; 1. GET Root /
   (let* ((env (list :path-info "/" :request-method :get))
          (res (cl-bbs/handlers:handle-request env)))


### PR DESCRIPTION
This PR adds the Git commit hash and a link to the GitHub repository in the page footers of cl-bbs. It also integrates auto-capturing of this commit hash during Docker builds so that it updates dynamically on each deployment.