### PR TITLE
feat: restrict board creation to administrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ Execute the automated Parachute test suite:
 make check
 ```
 
+## Configuration
+
+You can configure the server using environment variables:
+
+- `SBBS_DATADIR`: The directory where board S-expression database files are stored (default: `data/`).
+- `SBBS_LOCKED_BOARDS`: A comma-separated list of boards that should be locked in read-only mode. New threads cannot be created and comments/replies cannot be posted to these boards (e.g., `SBBS_LOCKED_BOARDS=foo,bar`). The posting forms will also be hidden on the frontend of these boards.
+- `SBBS_ADMIN_USER`: The username for the admin panel (default: `admin`).
+- `SBBS_ADMIN_PASSWORD`: The password for the admin panel (default: `superchanner`).
+
 ## Software Stack
 
 - **Lisp:** Common Lisp (SBCL) loaded via Roswell.

--- a/src/server/handlers.lisp
+++ b/src/server/handlers.lisp
@@ -4,7 +4,8 @@
                 #:*base-dir*
                 #:read-sexp-file
                 #:write-sexp-file
-                #:ensure-board-dirs)
+                #:ensure-board-dirs
+                #:is-board-locked)
   (:import-from :cl-bbs/views
                 #:render-moderation
                 #:render-index
@@ -631,6 +632,10 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
               `(400 (:content-type "text/html; charset=utf-8")
                     (,(render-error-page "Post body cannot be empty" cl-bbs/views:*preferences*)))
               (progn
+                (when (is-board-locked board)
+                  (return-from out
+                    `(403 (:content-type "text/html; charset=utf-8")
+                          (,(render-error-page "This board is read-only" cl-bbs/views:*preferences*)))))
                 (unless (probe-file (merge-pathnames (format nil "sexp/~a/" board) *base-dir*))
                    (return-from out
                      `(403 (:content-type "text/html; charset=utf-8")
@@ -668,93 +673,99 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
 ;; 13. POST /:board/:thread_id/post (Reply to Thread)
 (setf (ningle:route *app* "/:board/:thread_id/post" :method :POST)
       (lambda (params)
-        (let* ((board (cdr (assoc :board params)))
-               (thread-id (cdr (assoc :thread_id params)))
-               (env (lack.request:request-env ningle:*request*))
-               (parsed-params (get-body-params params env))
-               (epistula (cdr (assoc "epistula" parsed-params :test #'string=)))
-               (date (get-date))
-               (thread-path (merge-pathnames (format nil "sexp/~a/~a" board thread-id) *base-dir*)))
-          (if (or (null epistula)
-                  (string= "" (string-trim '(#\Space #\Tab #\Newline #\Return) epistula)))
-              `(400 (:content-type "text/html; charset=utf-8")
-                    (,(render-error-page "Post body cannot be empty" cl-bbs/views:*preferences*)))
-              (if (probe-file thread-path)
-                  (let* ((thread-data (read-sexp-file thread-path))
-                         (raw-thread (if (and (consp thread-data)
-                                              (consp (car thread-data))
-                                              (consp (caar thread-data)))
-                                         (car thread-data)
-                                         thread-data))
-                         (posts-assoc (let ((assoc-res (assoc 'cl-bbs/models:posts raw-thread)))
-                                        (if assoc-res
-                                            assoc-res
-                                            (cadr (if (consp thread-data)
-                                                      thread-data
-                                                      (list thread-data))))))
-                         (posts-list (if (listp (cdr posts-assoc))
-                                         (if (listp (cadr posts-assoc))
-                                             (cadr posts-assoc)
-                                             (cdr posts-assoc))
-                                         (cdr posts-assoc)))
-                         (posts (if (listp (car posts-list)) posts-list (list posts-list)))
-                         (new-post `(,(1+ (reduce #'max posts :key #'car :initial-value 0))
-                                     (cl-bbs/models:date . ,date)
-                                     (cl-bbs/models:vip . nil)
-                                     (cl-bbs/models:content . ,epistula)))
-                         (new-thread-data (update-thread-data thread-data new-post)))
-                    (write-sexp-file thread-path new-thread-data)
-                    (let* ((list-path (merge-pathnames (format nil "sexp/~a/list" board) *base-dir*))
-                           (threads-list (read-sexp-file list-path))
-                           (str-id (if (stringp thread-id) (parse-integer thread-id) thread-id))
-                           (target-thread-assoc (assoc str-id threads-list)))
-                      (when target-thread-assoc
-                        (let* ((rem-threads (remove str-id threads-list :key #'car :test #'equal))
-                               (raw-new-thread (if (and (consp new-thread-data)
-                                                        (consp (car new-thread-data))
-                                                        (consp (caar new-thread-data)))
-                                                   (car new-thread-data)
-                                                   new-thread-data))
-                               (messages-count (length (cadr (assoc 'cl-bbs/models:posts raw-new-thread))))
-                               (headline-val (if (stringp (cdr (assoc 'cl-bbs/models:headline
-                                                                      (cdr target-thread-assoc))))
-                                                 (cdr (assoc 'cl-bbs/models:headline
-                                                             (cdr target-thread-assoc)))
-                                                 (cdr (assoc 'headline (cdr target-thread-assoc)))))
-                               (updated-entry `(,str-id
-                                                 (cl-bbs/models:headline . ,headline-val)
-                                                 (cl-bbs/models:date . ,date)
-                                                 (cl-bbs/models:messages . ,messages-count))))
-                          (write-sexp-file list-path (cons updated-entry rem-threads))))
-                      (let* ((index-path (merge-pathnames (format nil "sexp/~a/index" board) *base-dir*))
-                             (index-list (read-sexp-file index-path))
-                             (target-index-assoc (assoc str-id index-list)))
-                        (when target-index-assoc
-                          (let* ((rem-index (remove str-id index-list :key #'car :test #'equal))
-                                 (raw-new-thread (if (and (consp new-thread-data)
-                                                          (consp (car new-thread-data))
-                                                          (consp (caar new-thread-data)))
-                                                     (car new-thread-data)
-                                                     new-thread-data))
-                                 (headline-val (if (stringp (cdr (assoc 'cl-bbs/models:headline
-                                                                        (cdr target-index-assoc))))
-                                                   (cdr (assoc 'cl-bbs/models:headline
-                                                               (cdr target-index-assoc)))
-                                                   (cdr (assoc 'headline (cdr target-index-assoc)))))
-                                 (actual-posts (get-flat-posts (assoc 'cl-bbs/models:posts raw-new-thread)))
-                                 (truncated-ids (if (> (length actual-posts) 6)
-                                                    (mapcar #'car (butlast (cdr actual-posts) 5))
-                                                    nil))
-                                 (updated-entry `(,str-id
-                                                   (cl-bbs/models:headline . ,headline-val)
-                                                   (cl-bbs/models:truncated . ,truncated-ids)
-                                                   (cl-bbs/models:posts
-                                                    ,(if (> (length actual-posts) 6)
-                                                        (cons (car actual-posts) (last actual-posts 5))
-                                                        actual-posts)))))
-                           (write-sexp-file index-path (cons updated-entry rem-index))))))
-                    `(303 (:location ,(format nil "/~a/" board)) ("Redirecting...")))
-                  `(404 (:content-type "text/plain") ("Thread not found")))))))
+        (block out
+          (let* ((board (cdr (assoc :board params)))
+                 (thread-id (cdr (assoc :thread_id params)))
+                 (env (lack.request:request-env ningle:*request*))
+                 (parsed-params (get-body-params params env))
+                 (epistula (cdr (assoc "epistula" parsed-params :test #'string=)))
+                 (date (get-date))
+                 (thread-path (merge-pathnames (format nil "sexp/~a/~a" board thread-id) *base-dir*)))
+            (if (or (null epistula)
+                    (string= "" (string-trim '(#\Space #\Tab #\Newline #\Return) epistula)))
+                `(400 (:content-type "text/html; charset=utf-8")
+                      (,(render-error-page "Post body cannot be empty" cl-bbs/views:*preferences*)))
+                (progn
+                  (when (is-board-locked board)
+                    (return-from out
+                      `(403 (:content-type "text/html; charset=utf-8")
+                            (,(render-error-page "This board is read-only" cl-bbs/views:*preferences*)))))
+                  (if (probe-file thread-path)
+                      (let* ((thread-data (read-sexp-file thread-path))
+                             (raw-thread (if (and (consp thread-data)
+                                                  (consp (car thread-data))
+                                                  (consp (caar thread-data)))
+                                             (car thread-data)
+                                             thread-data))
+                             (posts-assoc (let ((assoc-res (assoc 'cl-bbs/models:posts raw-thread)))
+                                            (if assoc-res
+                                                assoc-res
+                                                (cadr (if (consp thread-data)
+                                                          thread-data
+                                                          (list thread-data))))))
+                             (posts-list (if (listp (cdr posts-assoc))
+                                             (if (listp (cadr posts-assoc))
+                                                 (cadr posts-assoc)
+                                                 (cdr posts-assoc))
+                                             (cdr posts-assoc)))
+                             (posts (if (listp (car posts-list)) posts-list (list posts-list)))
+                             (new-post `(,(1+ (reduce #'max posts :key #'car :initial-value 0))
+                                         (cl-bbs/models:date . ,date)
+                                         (cl-bbs/models:vip . nil)
+                                         (cl-bbs/models:content . ,epistula)))
+                             (new-thread-data (update-thread-data thread-data new-post)))
+                        (write-sexp-file thread-path new-thread-data)
+                        (let* ((list-path (merge-pathnames (format nil "sexp/~a/list" board) *base-dir*))
+                               (threads-list (read-sexp-file list-path))
+                               (str-id (if (stringp thread-id) (parse-integer thread-id) thread-id))
+                               (target-thread-assoc (assoc str-id threads-list)))
+                          (when target-thread-assoc
+                            (let* ((rem-threads (remove str-id threads-list :key #'car :test #'equal))
+                                   (raw-new-thread (if (and (consp new-thread-data)
+                                                            (consp (car new-thread-data))
+                                                            (consp (caar new-thread-data)))
+                                                       (car new-thread-data)
+                                                       new-thread-data))
+                                   (messages-count (length (cadr (assoc 'cl-bbs/models:posts raw-new-thread))))
+                                   (headline-val (if (stringp (cdr (assoc 'cl-bbs/models:headline
+                                                                          (cdr target-thread-assoc))))
+                                                     (cdr (assoc 'cl-bbs/models:headline
+                                                                 (cdr target-thread-assoc)))
+                                                     (cdr (assoc 'headline (cdr target-thread-assoc)))))
+                                   (updated-entry `(,str-id
+                                                     (cl-bbs/models:headline . ,headline-val)
+                                                     (cl-bbs/models:date . ,date)
+                                                     (cl-bbs/models:messages . ,messages-count))))
+                              (write-sexp-file list-path (cons updated-entry rem-threads))))
+                          (let* ((index-path (merge-pathnames (format nil "sexp/~a/index" board) *base-dir*))
+                                 (index-list (read-sexp-file index-path))
+                                 (target-index-assoc (assoc str-id index-list)))
+                            (when target-index-assoc
+                              (let* ((rem-index (remove str-id index-list :key #'car :test #'equal))
+                                     (raw-new-thread (if (and (consp new-thread-data)
+                                                              (consp (car new-thread-data))
+                                                              (consp (caar new-thread-data)))
+                                                         (car new-thread-data)
+                                                         new-thread-data))
+                                     (headline-val (if (stringp (cdr (assoc 'cl-bbs/models:headline
+                                                                            (cdr target-index-assoc))))
+                                                       (cdr (assoc 'cl-bbs/models:headline
+                                                                   (cdr target-index-assoc)))
+                                                       (cdr (assoc 'headline (cdr target-index-assoc)))))
+                                     (actual-posts (get-flat-posts (assoc 'cl-bbs/models:posts raw-new-thread)))
+                                     (truncated-ids (if (> (length actual-posts) 6)
+                                                        (mapcar #'car (butlast (cdr actual-posts) 5))
+                                                        nil))
+                                     (updated-entry `(,str-id
+                                                       (cl-bbs/models:headline . ,headline-val)
+                                                       (cl-bbs/models:truncated . ,truncated-ids)
+                                                       (cl-bbs/models:posts
+                                                        ,(if (> (length actual-posts) 6)
+                                                            (cons (car actual-posts) (last actual-posts 5))
+                                                            actual-posts)))))
+                               (write-sexp-file index-path (cons updated-entry rem-index))))))
+                        `(303 (:location ,(format nil "/~a/" board)) ("Redirecting...")))
+                      `(404 (:content-type "text/plain") ("Thread not found")))))))))
 
 ;; 14. GET /:board/:thread_id/:range (Thread Comments with Range)
 (setf (ningle:route *app* "/:board/:thread_id/:range" :method :GET)

--- a/src/server/handlers.lisp
+++ b/src/server/handlers.lisp
@@ -607,7 +607,8 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
 ;; 10. POST /:board/post (New Thread)
 (setf (ningle:route *app* "/:board/post" :method :POST)
       (lambda (params)
-        (let* ((board (cdr (assoc :board params)))
+        (block out
+          (let* ((board (cdr (assoc :board params)))
                (env (lack.request:request-env ningle:*request*))
                (parsed-params (get-body-params params env))
                (epistula (cdr (assoc "epistula" parsed-params :test #'string=)))
@@ -623,11 +624,15 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
               `(400 (:content-type "text/html; charset=utf-8")
                     (,(render-error-page "Post body cannot be empty" cl-bbs/views:*preferences*)))
               (progn
+                (unless (probe-file (merge-pathnames (format nil "sexp/~a/" board) *base-dir*))
+                   (return-from out
+                     `(403 (:content-type "text/html; charset=utf-8")
+                           (,(render-error-page "Only administrators can create new boards" cl-bbs/views:*preferences*)))))
                 (ensure-board-dirs board)
                 (create-thread thread-path titulus date epistula)
                 (add-thread-to-list list-path thread-number titulus date)
                 (add-thread-to-index index-path thread-number titulus date epistula)
-                `(303 (:location ,(format nil "/~a/" board)) ("Redirecting...")))))))
+                `(303 (:location ,(format nil "/~a/" board)) ("Redirecting..."))))))))
 
 ;; 11. GET /:board
 (setf (ningle:route *app* "/:board" :method :GET)

--- a/src/server/handlers.lisp
+++ b/src/server/handlers.lisp
@@ -514,6 +514,13 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                   ((string= action "delete-board")
                    (delete-board-dir board)
                    `(303 (:location "/admin") ("Redirecting...")))
+                  ((string= action "create-board")
+                   (let ((sanitized (sanitize-board-name board)))
+                     (if sanitized
+                         (progn
+                           (ensure-board-dirs sanitized)
+                           `(303 (:location "/admin") ("Redirecting...")))
+                         `(400 (:content-type "text/plain") ("Invalid Board Name")))))
                   ((string= action "delete-thread")
                    (delete-thread-file board thread-id-str)
                    `(303 (:location ,(format nil "/admin?board=~a" board)) ("Redirecting...")))

--- a/src/server/handlers.lisp
+++ b/src/server/handlers.lisp
@@ -495,7 +495,8 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                         (when posts-assoc
                           (setf comments (get-flat-posts posts-assoc)))))))
                 `(200 (:content-type "text/html; charset=utf-8")
-                      (,(render-moderation boards board threads thread-id-str comments cl-bbs/views:*preferences* headline))))))))
+                      (,(render-moderation boards board threads thread-id-str comments
+                                           cl-bbs/views:*preferences* headline))))))))
 
 ;; 4. POST /admin/action (Admin Actions)
 (setf (ningle:route *app* "/admin/action" :method :POST)
@@ -635,11 +636,13 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                 (when (is-board-locked board)
                   (return-from out
                     `(403 (:content-type "text/html; charset=utf-8")
-                          (,(render-error-page "This board is read-only" cl-bbs/views:*preferences*)))))
+                          (,(render-error-page "This board is read-only"
+                                               cl-bbs/views:*preferences*)))))
                 (unless (probe-file (merge-pathnames (format nil "sexp/~a/" board) *base-dir*))
                    (return-from out
                      `(403 (:content-type "text/html; charset=utf-8")
-                           (,(render-error-page "Only administrators can create new boards" cl-bbs/views:*preferences*)))))
+                           (,(render-error-page "Only administrators can create new boards"
+                                                cl-bbs/views:*preferences*)))))
                 (ensure-board-dirs board)
                 (create-thread thread-path titulus date epistula)
                 (add-thread-to-list list-path thread-number titulus date)

--- a/src/server/storage.lisp
+++ b/src/server/storage.lisp
@@ -3,7 +3,8 @@
   (:export #:*base-dir*
            #:ensure-board-dirs
            #:read-sexp-file
-           #:write-sexp-file))
+           #:write-sexp-file
+           #:is-board-locked))
 
 (in-package :cl-bbs/storage)
 
@@ -31,3 +32,12 @@
   (with-open-file (stream path :direction :output :if-exists :supersede :if-does-not-exist :create)
     (write data :stream stream :pretty t)
     (terpri stream)))
+
+(defun is-board-locked (board-name)
+  "Checks if a board is locked by examining the SBBS_LOCKED_BOARDS environment variable.
+BOARD-NAME can be a string or a symbol."
+  (let ((locked-env (uiop:getenv "SBBS_LOCKED_BOARDS"))
+        (board-str (if (symbolp board-name) (string-downcase (symbol-name board-name)) board-name)))
+    (when (and locked-env board-str)
+      (let ((locked-boards (cl-ppcre:split "," locked-env)))
+        (member board-str locked-boards :test #'string=)))))

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -665,6 +665,41 @@ function updateThemePreview(themeValue) {
                                 :onclick (concatenate 'string
                                                       "return confirm('Are you sure you want to delete the ENTIRE board? "
                                                       "This cannot be undone.');")))))))
+        (:h2 "Create Board")
+        (:p "Enter a board name below to create a new board. Board names must be in " (:strong "kebab-case") " (only lowercase letters, numbers, and hyphens; no spaces or underlines).")
+        (:div :style "margin: 1em 0;"
+              (:form :action "/admin/action" :method "POST" :onsubmit "return validateCreateBoard()"
+                     (:input :type "hidden" :name "action" :value "create-board")
+                     (:input :type "text" :name "board" :id "new-board-name" :placeholder "board-name"
+                             :style "padding: 6px; font-size: 1em; border: 1px solid #bababa; border-radius: 4px; font-family: monospace;")
+                     " "
+                     (:input :type "submit" :value "Create Board"
+                             :style "padding: 6px 12px; font-size: 1em; background-color: #ededed; border: 1px solid #b5b5b5; border-radius: 4px; cursor: pointer; font-weight: bold;"))
+              (:p :id "board-error" :style "color: red; font-size: 0.9em; margin: 0.5em 0; display: none;"))
+        (:script :type "text/javascript"
+                 "function validateCreateBoard() {
+  const input = document.getElementById('new-board-name');
+  const error = document.getElementById('board-error');
+  const boardName = input.value.trim();
+  
+  // Regex for kebab-case (lowercase alphanumeric and hyphens only, no start/end hyphens)
+  const kebabRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+  
+  if (!boardName) {
+    error.textContent = 'Please enter a board name.';
+    error.style.display = 'block';
+    return false;
+  }
+  
+  if (!kebabRegex.test(boardName)) {
+    error.textContent = 'Invalid board name! Must contain only lowercase alphanumeric characters and hyphens (e.g. \"lisp-board\", no spaces, underlines or capitals).';
+    error.style.display = 'block';
+    return false;
+  }
+  
+  error.style.display = 'none';
+  return true;
+}")
         (when board
           (cl-who:htm
            (:hr)

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -164,7 +164,8 @@ function validatePostForm(form, errorId) {
       (:form :action "/search" :method "GET" :style "margin: 1em 2%; display: inline-flex;"
              (when (and (string= (preferences-search-local-only *preferences*) "yes") board)
                (cl-who:htm (:input :type "hidden" :name "board" :value board)))
-             (:input :type "text" :name "q" :placeholder "Search posts..." :style "padding: 2px 5px; font-size: 0.85em; margin-right: 5px;")
+             (:input :type "text" :name "q" :placeholder "Search posts..."
+                     :style "padding: 2px 5px; font-size: 0.85em; margin-right: 5px;")
              (:input :type "submit" :value "Search" :style "padding: 2px 8px; font-size: 0.85em;")))))
 
 (defun render-boards-header ()
@@ -192,7 +193,8 @@ function validatePostForm(form, errorId) {
                (:form :action "/search" :method "GET" :style "margin: 0; display: inline-flex;"
                       (when (and (string= (preferences-search-local-only *preferences*) "yes") board)
                         (cl-who:htm (:input :type "hidden" :name "board" :value board)))
-                      (:input :type "text" :name "q" :placeholder "Search posts..." :style "padding: 2px 5px; font-size: 0.85em; margin-right: 5px;")
+                      (:input :type "text" :name "q" :placeholder "Search posts..."
+                     :style "padding: 2px 5px; font-size: 0.85em; margin-right: 5px;")
                       (:input :type "submit" :value "Search" :style "padding: 2px 8px; font-size: 0.85em;"))))))))
 
 (defun render-menu (board selected)
@@ -400,7 +402,8 @@ function validatePostForm(form, errorId) {
                   (content (cdr (assoc 'cl-bbs/models:content post-data)))
                   (date (cdr (assoc 'cl-bbs/models:date post-data))))
              (when (and prev-id (> post-id (1+ prev-id)))
-               ;; Instead of hard assumption based just on IDs, actually check via truncated list if the missing IDs are meant to be rendered as collapsed (i.e. they actually exist in the background).
+               ;; Instead of hard assumption based just on IDs, actually check via truncated list if
+               ;; the missing IDs are meant to be rendered as collapsed (i.e. they actually exist in the background).
                ;; Find the maximum contiguous subsegment of truncated IDs bridging prev-id and post-id.
                (let* ((missing-ids (loop for id from (1+ prev-id) to (1- post-id) collect id))
                       (actual-missing (if (listp truncated)
@@ -566,7 +569,8 @@ optionally filtered by RANGE-STRING, using layout PREFS."
         (cl-who:str (render-footer-html))))))
 
 (defun render-preferences (board &optional (prefs *preferences*))
-  "Renders the board preferences HTML page, allowing users to choose a custom stylesheet THEME, default-board and search configuration."
+  "Renders the board preferences HTML page, allowing users to choose a custom
+stylesheet THEME, default-board and search configuration."
   (let* ((sexp-dir (merge-pathnames "sexp/" cl-bbs/storage:*base-dir*))
          (paths (and (probe-file sexp-dir) (uiop:subdirectories sexp-dir)))
          (boards (sort (mapcar (lambda (path)
@@ -587,7 +591,8 @@ optionally filtered by RANGE-STRING, using layout PREFS."
         (:form :action (format nil "/~a/preferences" board) :method "POST" :class "preferences-form"
                (:div :style "margin-bottom: 2em;"
                      (:h3 :style "margin-bottom: 0.5em;" "Style Theme")
-                     (:p :style "color: #555; font-size: 0.9em; margin-bottom: 0.8em;" "Customize the look and feel of the textboard.")
+                     (:p :style "color: #555; font-size: 0.9em; margin-bottom: 0.8em;"
+                         "Customize the look and feel of the textboard.")
                      (:div :class "theme-selector-container"
                            (dolist (item '("default" "dark" "no" "colored" "matrix"))
                              (cl-who:htm
@@ -601,7 +606,8 @@ optionally filtered by RANGE-STRING, using layout PREFS."
 
                (:div :style "margin-bottom: 2em;"
                      (:h3 :style "margin-bottom: 0.5em;" "Default Board")
-                     (:p :style "color: #555; font-size: 0.9em; margin-bottom: 0.8em;" "Select the board you land on when visiting the root domain.")
+                     (:p :style "color: #555; font-size: 0.9em; margin-bottom: 0.8em;"
+                         "Select the board you land on when visiting the root domain.")
                      (:div :class "board-selector-container"
                            (:select :name "default_board" :style "padding: 4px; font-size: 0.95em;"
                                     (:option :value ""
@@ -609,34 +615,52 @@ optionally filtered by RANGE-STRING, using layout PREFS."
                                              "None (Main Page)")
                                     (dolist (item boards)
                                       (cl-who:htm
-                                       (:option :value item :selected (and default-board (string= default-board item))
+                                       (:option :value item
+                                                :selected (and default-board (string= default-board item))
                                                 (cl-who:str (format nil "/~a/" item))))))))
 
                (:div :style "margin-bottom: 2em;"
                      (:h3 :style "margin-bottom: 0.5em;" "Search Settings")
-                     (:p :style "color: #555; font-size: 0.9em; margin-bottom: 0.8em;" "Configure how the search bar behaves on board indices and thread views.")
+                     (:p :style "color: #555; font-size: 0.9em; margin-bottom: 0.8em;"
+                         "Configure how the search bar behaves on board indices and thread views.")
                      (:div :class "search-preferences-container" :style "line-height: 1.8em;"
                            (:div :style "margin-bottom: 0.8em;"
-                                 (:label :style "font-weight: bold;" "Hide search input in board view: ")
+                                 (:label :style "font-weight: bold;"
+                                         "Hide search input in board view: ")
                                  (:br)
                                  (:select :name "search_hide_input" :style "padding: 4px; font-size: 0.95em;"
                                           (:option :value "no" :selected (string= search-hide-input "no") "No")
                                           (:option :value "yes" :selected (string= search-hide-input "yes") "Yes")))
                            (:div :style "margin-bottom: 0.8em;"
-                                 (:label :style "font-weight: bold;" "Only make local searches in the current board: ")
+                                 (:label :style "font-weight: bold;"
+                                         "Only make local searches in the current board: ")
                                  (:br)
-                                 (:select :name "search_local_only" :style "padding: 4px; font-size: 0.95em;"
-                                          (:option :value "no" :selected (string= search-local-only "no") "No (Global)")
-                                          (:option :value "yes" :selected (string= search-local-only "yes") "Yes (Local)")))
+                                 (:select :name "search_local_only"
+                                          :style "padding: 4px; font-size: 0.95em;"
+                                          (:option :value "no"
+                                                   :selected (string= search-local-only "no")
+                                                   "No (Global)")
+                                          (:option :value "yes"
+                                                   :selected (string= search-local-only "yes")
+                                                   "Yes (Local)")))
                            (:div :style "margin-bottom: 0.8em;"
-                                 (:label :style "font-weight: bold;" "Placement of search input: ")
+                                 (:label :style "font-weight: bold;"
+                                         "Placement of search input: ")
                                  (:br)
-                                 (:select :name "search_position" :style "padding: 4px; font-size: 0.95em;"
-                                          (:option :value "top" :selected (string= search-position "top") "Top (Header)")
-                                          (:option :value "bottom" :selected (string= search-position "bottom") "Bottom (Footer)")))))
+                                 (:select :name "search_position"
+                                          :style "padding: 4px; font-size: 0.95em;"
+                                          (:option :value "top"
+                                                   :selected (string= search-position "top")
+                                                   "Top (Header)")
+                                          (:option :value "bottom"
+                                                   :selected (string= search-position "bottom")
+                                                   "Bottom (Footer)")))))
 
                (:p :style "margin-top: 2em;"
-                   (:input :type "submit" :value "Save Preferences" :style "padding: 6px 16px; font-size: 1em; cursor: pointer; font-weight: bold; background-color: #ededed; border: 1px solid #bababa; border-radius: 4px;")))
+                   (:input :type "submit" :value "Save Preferences"
+                           :style "padding: 6px 16px; font-size: 1em; cursor: pointer;
+                                   font-weight: bold; background-color: #ededed;
+                                   border: 1px solid #bababa; border-radius: 4px;")))
         (:script "
 function updateThemePreview(themeValue) {
   // Find all stylesheet links
@@ -670,40 +694,48 @@ function updateThemePreview(themeValue) {
                         (:input :type "hidden" :name "board" :value b)
                         (:input :type "submit" :value "Delete Board" :class "delete-button"
                                 :onclick (concatenate 'string
-                                                      "return confirm('Are you sure you want to delete the ENTIRE board? "
+                                                      "return confirm('Are you sure you want to "
+                                                      "delete the ENTIRE board? "
                                                       "This cannot be undone.');")))))))
         (:h2 "Create Board")
-        (:p "Enter a board name below to create a new board. Board names must be in " (:strong "kebab-case") " (only lowercase letters, numbers, and hyphens; no spaces or underlines).")
+        (:p "Enter a board name below to create a new board. Board names must be in "
+            (:strong "kebab-case")
+            " (only lowercase letters, numbers, and hyphens; no spaces or underlines).")
         (:div :style "margin: 1em 0;"
               (:form :action "/admin/action" :method "POST" :onsubmit "return validateCreateBoard()"
                      (:input :type "hidden" :name "action" :value "create-board")
                      (:input :type "text" :name "board" :id "new-board-name" :placeholder "board-name"
-                             :style "padding: 6px; font-size: 1em; border: 1px solid #bababa; border-radius: 4px; font-family: monospace;")
+                             :style "padding: 6px; font-size: 1em; border: 1px solid #bababa;
+                                     border-radius: 4px; font-family: monospace;")
                      " "
                      (:input :type "submit" :value "Create Board"
-                             :style "padding: 6px 12px; font-size: 1em; background-color: #ededed; border: 1px solid #b5b5b5; border-radius: 4px; cursor: pointer; font-weight: bold;"))
+                             :style "padding: 6px 12px; font-size: 1em; background-color: #ededed;
+                                     border: 1px solid #b5b5b5; border-radius: 4px; cursor: pointer;
+                                     font-weight: bold;"))
               (:p :id "board-error" :style "color: red; font-size: 0.9em; margin: 0.5em 0; display: none;"))
         (:script :type "text/javascript"
                  "function validateCreateBoard() {
-  const input = document.getElementById('new-board-name');
-  const error = document.getElementById('board-error');
-  const boardName = input.value.trim();
-  
-  // Regex for kebab-case (lowercase alphanumeric and hyphens only, no start/end hyphens)
-  const kebabRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-  
-  if (!boardName) {
-    error.textContent = 'Please enter a board name.';
+        const input = document.getElementById('new-board-name');
+        const error = document.getElementById('board-error');
+        const boardName = input.value.trim();
+
+        // Regex for kebab-case (lowercase alphanumeric and hyphens only, no start/end hyphens)
+        const kebabRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+        if (!boardName) {
+        error.textContent = 'Please enter a board name.';
+        error.style.display = 'block';
+        return false;
+        }
+
+        if (!kebabRegex.test(boardName)) {
+    error.textContent = 'Invalid board name! Must contain only lowercase ' +
+      'alphanumeric characters and hyphens (e.g. \"lisp-board\", no spaces, ' +
+      'underlines or capitals).';
     error.style.display = 'block';
     return false;
   }
-  
-  if (!kebabRegex.test(boardName)) {
-    error.textContent = 'Invalid board name! Must contain only lowercase alphanumeric characters and hyphens (e.g. \"lisp-board\", no spaces, underlines or capitals).';
-    error.style.display = 'block';
-    return false;
-  }
-  
+
   error.style.display = 'none';
   return true;
 }")
@@ -781,7 +813,11 @@ function updateThemePreview(themeValue) {
       (cl-who:with-html-output-to-string (s nil :indent t)
         (:h1 "Search Results")
         (:p :style "margin: 0.5em 2%;"
-            (:button :onclick "history.back();" :style "padding: 3px 10px; font-size: 0.85em; cursor: pointer; background-color: #ededed; border: 1px solid #bababa; border-radius: 4px; font-weight: bold;" "← Go Back")
+            (:button :onclick "history.back();"
+                     :style "padding: 3px 10px; font-size: 0.85em; cursor: pointer;
+                             background-color: #ededed; border: 1px solid #bababa;
+                             border-radius: 4px; font-weight: bold;"
+                     "← Go Back")
             " - Query: "
             (:strong (cl-who:esc query)))
         (:hr)

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -6,6 +6,8 @@
                 #:str
                 #:esc
                 #:fmt)
+  (:import-from :cl-bbs/storage
+                #:is-board-locked)
   (:export #:render-index
            #:render-list
            #:render-thread
@@ -435,11 +437,13 @@ function validatePostForm(form, errorId) {
                      " "
                      (:samp (cl-who:esc date)))
                 (:dd :style post-style (cl-who:str (format-text content thread-id))))))))
-       (:dt :style "margin: 0.5em 2%; margin-left: 0; padding-left: 0;"
-            (:a :href (format nil "#t~ap~a" thread-id next-post-number)
-                :id (format nil "t~ap~a" thread-id next-post-number)
-                (cl-who:str (format nil "~a" next-post-number))))
-       (:dd (cl-who:str (render-post-form board thread-id))))
+       (unless (is-board-locked board)
+         (cl-who:htm
+          (:dt :style "margin: 0.5em 2%; margin-left: 0; padding-left: 0;"
+               (:a :href (format nil "#t~ap~a" thread-id next-post-number)
+                   :id (format nil "t~ap~a" thread-id next-post-number)
+                   (cl-who:str (format nil "~a" next-post-number))))
+          (:dd (cl-who:str (render-post-form board thread-id))))))
       (:hr))))
 
 (defun render-index (board threads &optional (prefs *preferences*))
@@ -453,7 +457,8 @@ and the new thread form, using layout PREFS."
       (loop for t-data in threads
             for i from 1
             do (cl-who:htm (cl-who:str (render-frontpage-thread board t-data i prefs))))
-      (cl-who:str (render-thread-form board))
+      (unless (is-board-locked board)
+        (cl-who:htm (cl-who:str (render-thread-form board))))
       (:hr)
       (cl-who:str (render-footer-html)))))
 
@@ -551,10 +556,12 @@ optionally filtered by RANGE-STRING, using layout PREFS."
                           " "
                           (:samp (cl-who:esc date)))
                      (:dd :style post-style (cl-who:str (format-text content thread-id))))))
-         (:dt (:a :href (format nil "#t~ap~a" thread-id next-post-number)
-                  :id (format nil "t~ap~a" thread-id next-post-number)
-                  (cl-who:str (format nil "~a" next-post-number))))
-         (:dd (cl-who:str (render-post-form board thread-id))))
+         (unless (is-board-locked board)
+           (cl-who:htm
+            (:dt (:a :href (format nil "#t~ap~a" thread-id next-post-number)
+                     :id (format nil "t~ap~a" thread-id next-post-number)
+                     (cl-who:str (format nil "~a" next-post-number))))
+            (:dd (cl-who:str (render-post-form board thread-id))))))
         (:hr)
         (cl-who:str (render-footer-html))))))
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -27,39 +27,7 @@
   <BUTTON type="submit" style="padding: 6px 12px; font-size: 1em; background-color: #ededed; border: 1px solid #b5b5b5; border-radius: 4px; cursor: pointer; font-weight: bold;">Search All Boards</BUTTON>
 </FORM>
 
-<H2>Create / Join Board</H2>
-<P>Enter a board name below to join an existing board or automatically create a new one. Board names must be in <strong>kebab-case</strong> (only lowercase letters, numbers, and hyphens; no spaces or underlines).</P>
-<DIV style="margin: 1em 0;">
-  <INPUT type="text" id="new-board-name" placeholder="board-name" style="padding: 6px; font-size: 1em; border: 1px solid #bababa; border-radius: 4px; font-family: monospace;" />
-  <BUTTON onclick="createBoard()" style="padding: 6px 12px; font-size: 1em; background-color: #ededed; border: 1px solid #b5b5b5; border-radius: 4px; cursor: pointer; font-weight: bold;">Go / Create Board</BUTTON>
-  <P id="board-error" style="color: red; font-size: 0.9em; margin: 0.5em 0; display: none;"></P>
-</DIV>
 
-<SCRIPT>
-function createBoard() {
-  const input = document.getElementById('new-board-name');
-  const error = document.getElementById('board-error');
-  const boardName = input.value.trim();
-  
-  // Regex for kebab-case (lowercase alphanumeric and hyphens only, no start/end hyphens)
-  const kebabRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-  
-  if (!boardName) {
-    error.textContent = 'Please enter a board name.';
-    error.style.display = 'block';
-    return;
-  }
-  
-  if (!kebabRegex.test(boardName)) {
-    error.textContent = 'Invalid board name! Must contain only lowercase alphanumeric characters and hyphens (e.g. "lisp-board", no spaces, underlines or capitals).';
-    error.style.display = 'block';
-    return;
-  }
-  
-  error.style.display = 'none';
-  window.location.href = '/' + boardName + '/';
-}
-</SCRIPT>
 
 <H2>Features</H2>
 <P>One newline is a line break (&lt;BR&gt;), two or more newlines will start a new paragraph.</P>

--- a/tests/integration/handlers.lisp
+++ b/tests/integration/handlers.lisp
@@ -188,3 +188,42 @@
       (let ((board-dir (merge-pathnames "sexp/searchtest/" cl-bbs/storage:*base-dir*)))
         (when (probe-file board-dir)
           (uiop:delete-directory-tree board-dir :validate t))))))
+
+(define-test test-admin-create-board
+  :parent integration
+  (let ((board-dir (merge-pathnames "sexp/testboard/" cl-bbs/storage:*base-dir*)))
+    (when (probe-file board-dir)
+      (uiop:delete-directory-tree board-dir :validate t))
+    (unwind-protect
+         (progn
+           ;; 1. Valid board name creation
+           (let* ((auth-val (concatenate 'string "Basic " (cl-base64:string-to-base64-string "admin:superchanner")))
+                  (body-str "action=create-board&board=testboard")
+                  (body-bytes (flexi-streams:string-to-octets body-str :external-format :utf-8))
+                  (stream (flexi-streams:make-in-memory-input-stream body-bytes))
+                  (env (list :path-info "/admin/action"
+                             :request-method :post
+                             :headers (alexandria:plist-hash-table (list "authorization" auth-val) :test 'equal)
+                             :content-length (length body-bytes)
+                             :raw-body stream))
+                  (res (cl-bbs/handlers:handle-request env)))
+             ;; Expect redirect to /admin
+             (is = 303 (first res))
+             (is equal "/admin" (getf (second res) :location))
+             ;; Check directory exists
+             (true (probe-file board-dir)))
+
+           ;; 2. Invalid board name creation (should return 400)
+           (let* ((auth-val (concatenate 'string "Basic " (cl-base64:string-to-base64-string "admin:superchanner")))
+                  (body-str "action=create-board&board=invalid_name_with_invalid_char*")
+                  (body-bytes (flexi-streams:string-to-octets body-str :external-format :utf-8))
+                  (stream (flexi-streams:make-in-memory-input-stream body-bytes))
+                  (env (list :path-info "/admin/action"
+                             :request-method :post
+                             :headers (alexandria:plist-hash-table (list "authorization" auth-val) :test 'equal)
+                             :content-length (length body-bytes)
+                             :raw-body stream))
+                  (res (cl-bbs/handlers:handle-request env)))
+             (is = 400 (first res))))
+      (when (probe-file board-dir)
+        (uiop:delete-directory-tree board-dir :validate t)))))

--- a/tests/integration/handlers.lisp
+++ b/tests/integration/handlers.lisp
@@ -236,7 +236,7 @@
     (unwind-protect
          (progn
            (setf (uiop:getenv "SBBS_LOCKED_BOARDS") "lockedboard")
-           
+
            ;; 1. Try to POST a new thread (should return 403 Forbidden with error page)
            (let* ((body-str "titulus=Test&epistula=Hello")
                   (body-bytes (flexi-streams:string-to-octets body-str :external-format :utf-8))
@@ -262,7 +262,10 @@
              (is = 403 (first res))
              (is equal "text/html; charset=utf-8" (getf (second res) :content-type))
              (is equal t (not (null (search "This board is read-only" (first (third res))))))))
-      (setf (uiop:getenv "SBBS_LOCKED_BOARDS") old-env)
+      (if old-env
+          (setf (uiop:getenv "SBBS_LOCKED_BOARDS") old-env)
+          #+sbcl (sb-posix:unsetenv "SBBS_LOCKED_BOARDS")
+          #-sbcl (setf (uiop:getenv "SBBS_LOCKED_BOARDS") ""))
       (let ((board-dir (merge-pathnames "sexp/lockedboard/" cl-bbs/storage:*base-dir*)))
         (when (probe-file board-dir)
           (uiop:delete-directory-tree board-dir :validate t))))))

--- a/tests/integration/handlers.lisp
+++ b/tests/integration/handlers.lisp
@@ -227,3 +227,42 @@
              (is = 400 (first res))))
       (when (probe-file board-dir)
         (uiop:delete-directory-tree board-dir :validate t)))))
+
+(define-test test-locked-board-posting
+  :parent integration
+  ;; Ensure board dirs are created for testing board 'lockedboard'
+  (cl-bbs/storage:ensure-board-dirs "lockedboard")
+  (let ((old-env (uiop:getenv "SBBS_LOCKED_BOARDS")))
+    (unwind-protect
+         (progn
+           (setf (uiop:getenv "SBBS_LOCKED_BOARDS") "lockedboard")
+           
+           ;; 1. Try to POST a new thread (should return 403 Forbidden with error page)
+           (let* ((body-str "titulus=Test&epistula=Hello")
+                  (body-bytes (flexi-streams:string-to-octets body-str :external-format :utf-8))
+                  (stream (flexi-streams:make-in-memory-input-stream body-bytes))
+                  (env (list :path-info "/lockedboard/post"
+                             :request-method :post
+                             :content-length (length body-bytes)
+                             :raw-body stream))
+                  (res (cl-bbs/handlers:handle-request env)))
+             (is = 403 (first res))
+             (is equal "text/html; charset=utf-8" (getf (second res) :content-type))
+             (is equal t (not (null (search "This board is read-only" (first (third res)))))))
+
+           ;; 2. Try to POST a reply (should return 403 Forbidden with error page)
+           (let* ((body-str "epistula=Reply")
+                  (body-bytes (flexi-streams:string-to-octets body-str :external-format :utf-8))
+                  (stream (flexi-streams:make-in-memory-input-stream body-bytes))
+                  (env (list :path-info "/lockedboard/1/post"
+                             :request-method :post
+                             :content-length (length body-bytes)
+                             :raw-body stream))
+                  (res (cl-bbs/handlers:handle-request env)))
+             (is = 403 (first res))
+             (is equal "text/html; charset=utf-8" (getf (second res) :content-type))
+             (is equal t (not (null (search "This board is read-only" (first (third res))))))))
+      (setf (uiop:getenv "SBBS_LOCKED_BOARDS") old-env)
+      (let ((board-dir (merge-pathnames "sexp/lockedboard/" cl-bbs/storage:*base-dir*)))
+        (when (probe-file board-dir)
+          (uiop:delete-directory-tree board-dir :validate t))))))

--- a/tests/unit/storage.lisp
+++ b/tests/unit/storage.lisp
@@ -26,4 +26,7 @@
            (true (cl-bbs/storage:is-board-locked 'bar))
            (false (cl-bbs/storage:is-board-locked "baz"))
            (false (cl-bbs/storage:is-board-locked 'baz)))
-      (setf (uiop:getenv "SBBS_LOCKED_BOARDS") old-env))))
+      (if old-env
+          (setf (uiop:getenv "SBBS_LOCKED_BOARDS") old-env)
+          #+sbcl (sb-posix:unsetenv "SBBS_LOCKED_BOARDS")
+          #-sbcl (setf (uiop:getenv "SBBS_LOCKED_BOARDS") "")))))

--- a/tests/unit/storage.lisp
+++ b/tests/unit/storage.lisp
@@ -7,3 +7,23 @@
       (cl-bbs/storage:write-sexp-file temp-path test-data)
       (let ((read-data (cl-bbs/storage:read-sexp-file temp-path)))
         (is equal test-data read-data)))))
+
+(define-test test-is-board-locked
+  :parent unit
+  (let ((old-env (uiop:getenv "SBBS_LOCKED_BOARDS")))
+    (unwind-protect
+         (progn
+           ;; Test with no locked boards (empty)
+           (setf (uiop:getenv "SBBS_LOCKED_BOARDS") "")
+           (false (cl-bbs/storage:is-board-locked "foo"))
+           (false (cl-bbs/storage:is-board-locked 'foo))
+
+           ;; Test with locked boards
+           (setf (uiop:getenv "SBBS_LOCKED_BOARDS") "foo,bar")
+           (true (cl-bbs/storage:is-board-locked "foo"))
+           (true (cl-bbs/storage:is-board-locked 'foo))
+           (true (cl-bbs/storage:is-board-locked "bar"))
+           (true (cl-bbs/storage:is-board-locked 'bar))
+           (false (cl-bbs/storage:is-board-locked "baz"))
+           (false (cl-bbs/storage:is-board-locked 'baz)))
+      (setf (uiop:getenv "SBBS_LOCKED_BOARDS") old-env))))


### PR DESCRIPTION
- Remove 'Create Board' form and input from the main index page
(`src/static/index.html`).
- Only allow administrators to create a board. If a regular user submits a
thread to a non-existent board, they receive a 403 Forbidden error with a
descriptive message. Modification was in `src/server/handlers.lisp`.