### PR TITLE
feat: JSCL Snippet Execution and Interactive Playground

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM commonlispbr/roswell:latest
 RUN apt update && apt install libev4 wget file make -y
 WORKDIR /cl-bbs
 RUN ln -s /cl-bbs /root/.roswell/local-projects/cl-bbs
-COPY ./.qlot .qlot
+COPY ./.qlot* .
 COPY ./cl-bbs.asd cl-bbs.asd
 COPY ./src src
 COPY ./tests tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM commonlispbr/roswell:latest
 RUN apt update && apt install libev4 wget file make -y
 WORKDIR /cl-bbs
 RUN ln -s /cl-bbs /root/.roswell/local-projects/cl-bbs
+COPY ./.qlot .qlot
 COPY ./cl-bbs.asd cl-bbs.asd
 COPY ./src src
 COPY ./tests tests

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ docker-shell: docker-build
 	docker run --rm -it --entrypoint=/bin/bash $(DOCKER_IMG)
 
 docker-run: docker-build
-	# Note: default SchemeBBS port is 8222.
 	docker run --rm -it -p 8222:8222 -v $(PWD)/data:/cl-bbs/data $(DOCKER_IMG)
 
 .PHONY: check check-unit check-integration docker-check docker-build docker-lint lint lint-fix publish

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,10 @@ install-deps:
 server:
 	./roswell/cl-bbs-server.ros
 
-docker-build: dockerbuild
+cache-dependencies:
+	qlot install
 
-dockerbuild:
+docker-build:
 	docker build --build-arg APP_VERSION=$(APP_VERSION) --build-arg APP_COMMIT_HASH=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown") -t $(DOCKER_IMG) .
 
 docker-shell: docker-build

--- a/cl-bbs.asd
+++ b/cl-bbs.asd
@@ -60,7 +60,8 @@
                "lack"
                "lack-middleware-static"
                "lack-middleware-accesslog"
-               "bordeaux-threads")
+               "bordeaux-threads"
+               "colorize")
   :pathname "src"
   :components ((:file "package")
                (:module "server"

--- a/qlfile
+++ b/qlfile
@@ -9,3 +9,4 @@ ql yason
 ql bordeaux-threads
 ql parachute
 ql dexador
+ql colorize

--- a/scripts/download_clhs_map.sh
+++ b/scripts/download_clhs_map.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Shell script to download and set up the local Common Lisp HyperSpec symbol map for cl-bbs.
+set -e
+
+MAP_DIR="data/HyperSpec/Data"
+MAP_FILE="${MAP_DIR}/Map_Sym.txt"
+MAP_URL="http://www.lispworks.com/reference/HyperSpec/Data/Map_Sym.txt"
+
+echo "Creating local HyperSpec symbol map directory: ${MAP_DIR}..."
+mkdir -p "${MAP_DIR}"
+
+echo "Downloading official Map_Sym.txt from Lispworks..."
+if command -v curl >/dev/null 2>&1; then
+    curl -sSL "${MAP_URL}" -o "${MAP_FILE}"
+elif command -v wget >/dev/null 2>&1; then
+    wget -q "${MAP_URL}" -O "${MAP_FILE}"
+else
+    echo "Error: Neither curl nor wget found in the system!" >&2
+    exit 1
+fi
+
+echo "Successfully set up local Common Lisp HyperSpec symbol map at ${MAP_FILE}!"

--- a/src/server/handlers.lisp
+++ b/src/server/handlers.lisp
@@ -609,6 +609,18 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
           `(200 (:content-type "text/html; charset=utf-8")
                 (,(render-search-results (or query "") results cl-bbs/views:*preferences*))))))
 
+;; 6b-api. POST /api/colorize
+(setf (ningle:route *app* "/api/colorize" :method :POST)
+      (lambda (params)
+        (let* ((env (lack.request:request-env ningle:*request*))
+               (parsed-params (get-body-params params env))
+               (code (cdr (assoc "code" parsed-params :test #'string=))))
+          (if code
+              `(200 (:content-type "text/html; charset=utf-8")
+                    (,(handler-case (colorize:html-colorization :common-lisp code)
+                        (error () (cl-who:escape-string code)))))
+              `(400 (:content-type "text/plain") ("No code provided"))))))
+
 ;; 6c. GET /playground (Global Playground)
 (setf (ningle:route *app* "/playground" :method :GET)
       (lambda (params)

--- a/src/server/handlers.lisp
+++ b/src/server/handlers.lisp
@@ -64,6 +64,14 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                (cookie-theme (sanitize-theme-name (cdr (assoc "theme" cookies :test #'string=)))))
           (or cookie-theme "default")))))
 
+(defun get-syntax-theme-from-env (env)
+  "Retrieves the active syntax theme name from the request cookies."
+  (let* ((headers (getf env :headers))
+         (cookie-str (and headers (gethash "cookie" headers)))
+         (cookies (parse-cookies cookie-str))
+         (cookie-theme (sanitize-theme-name (cdr (assoc "syntax_theme" cookies :test #'string=)))))
+    (or cookie-theme "simple")))
+
 (defun get-search-hide-input-from-env (env)
   "Retrieves the setting for hiding search input in board view (returns \"yes\" or \"no\", default \"no\")."
   (let* ((headers (getf env :headers))
@@ -432,6 +440,7 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
             (intern (string-upcase (symbol-name (getf normalized-env :request-method))) :keyword)))
     (let ((cl-bbs/views:*preferences* (cl-bbs/views:make-preferences
                                        :theme (get-theme-from-env normalized-env)
+                                       :syntax-theme (get-syntax-theme-from-env normalized-env)
                                        :default-board (or (get-default-board-from-env normalized-env) "")
                                        :search-hide-input (get-search-hide-input-from-env normalized-env)
                                        :search-local-only (get-search-local-only-from-env normalized-env)
@@ -640,6 +649,7 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                (parsed-params (get-body-params params env))
                (board (cdr (assoc :board params)))
                (theme (cdr (assoc "theme" parsed-params :test #'string=)))
+               (syntax-theme (cdr (assoc "syntax_theme" parsed-params :test #'string=)))
                (default-board (let ((val (cdr (assoc "default_board" parsed-params :test #'string=))))
                                 (if val (string-trim '(#\Space #\Tab #\Newline #\Return) val) "")))
                (search-hide-input (let ((val (cdr (assoc "search_hide_input" parsed-params :test #'string=))))
@@ -650,6 +660,7 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                                   (if (member val '("top" "bottom") :test #'string=) val "top"))))
           `(303 (:location ,(format nil "/~a/preferences" board)
                  :set-cookie ,(format nil "theme=~a; Path=/; Max-Age=31536000" (or theme "default"))
+                 :set-cookie ,(format nil "syntax_theme=~a; Path=/; Max-Age=31536000" (or syntax-theme "simple"))
                  :set-cookie ,(format nil "default_board=~a; Path=/; Max-Age=31536000" (or default-board ""))
                  :set-cookie ,(format nil "search_hide_input=~a; Path=/; Max-Age=31536000" search-hide-input)
                  :set-cookie ,(format nil "search_local_only=~a; Path=/; Max-Age=31536000" search-local-only)

--- a/src/server/handlers.lisp
+++ b/src/server/handlers.lisp
@@ -13,7 +13,8 @@
                 #:render-preferences
                 #:render-error-page
                 #:render-thread
-                #:render-search-results)
+                #:render-search-results
+                #:render-playground)
   (:export #:handle-request))
 
 (in-package :cl-bbs/handlers)
@@ -598,6 +599,20 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                (results (if query (search-posts query board-filter) nil)))
           `(200 (:content-type "text/html; charset=utf-8")
                 (,(render-search-results (or query "") results cl-bbs/views:*preferences*))))))
+
+;; 6c. GET /playground (Global Playground)
+(setf (ningle:route *app* "/playground" :method :GET)
+      (lambda (params)
+        (declare (ignore params))
+        `(200 (:content-type "text/html; charset=utf-8")
+              (,(render-playground nil)))))
+
+;; 6d. GET /:board/playground (Board-scoped Playground)
+(setf (ningle:route *app* "/:board/playground" :method :GET)
+      (lambda (params)
+        (let ((board (cdr (assoc :board params))))
+          `(200 (:content-type "text/html; charset=utf-8")
+                (,(render-playground board))))))
 
 ;; 7. GET /:board/list
 (setf (ningle:route *app* "/:board/list" :method :GET)

--- a/src/server/main.lisp
+++ b/src/server/main.lisp
@@ -3,6 +3,23 @@
 (defvar *server* nil)
 (defvar *app* nil)
 
+;; Initialize colorize and HyperSpec lookup paths safely
+(defun init-colorize ()
+  (setf colorize:*debug* nil)
+  (handler-case
+      (let* ((base-dir (asdf:system-source-directory :cl-bbs/server))
+             (local-clhs-dir (and base-dir (merge-pathnames "data/HyperSpec/" base-dir)))
+             (local-map-file (and local-clhs-dir (merge-pathnames "Data/Map_Sym.txt" local-clhs-dir))))
+        (if (and local-map-file (probe-file local-map-file))
+            (progn
+              (setf clhs-lookup::*hyperspec-pathname* local-clhs-dir)
+              (setf clhs-lookup::*hyperspec-map-file* local-map-file))
+            (setf clhs-lookup::*hyperspec-map-file* #p"nonexistent-map-sym.txt")))
+    (error (e)
+      (declare (ignore e))
+      (setf clhs-lookup::*hyperspec-map-file* #p"nonexistent-map-sym.txt"))))
+
+
 (defun make-real-ip-middleware (app)
   (lambda (env)
     (let ((x-forwarded-for (gethash "x-forwarded-for" (getf env :headers))))
@@ -23,6 +40,7 @@
 
 (defun start-app (host port &key (async t))
   "Starts the Hunchentoot server running the cl-bbs application on the specified PORT."
+  (init-colorize)
   (when *server*
     (stop-app))
   (setf *app* (build-app))

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -30,7 +30,7 @@
 
 ;; Initialize colorize and HyperSpec lookup paths safely
 (setf colorize:*debug* nil)
-(eval-when (:load-toplevel :execute)
+(eval-when (:execute)
   (handler-case
       (let* ((base-dir (asdf:system-source-directory :cl-bbs/server))
              (local-clhs-dir (and base-dir (merge-pathnames "data/HyperSpec/" base-dir)))

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -19,6 +19,7 @@
            #:preferences
            #:make-preferences
            #:preferences-theme
+           #:preferences-syntax-theme
            #:preferences-default-board
            #:preferences-search-hide-input
            #:preferences-search-local-only
@@ -29,6 +30,7 @@
 
 (defstruct preferences
   (theme "default")
+  (syntax-theme "simple")
   (default-board "")
   (search-hide-input "no")
   (search-local-only "no")
@@ -74,7 +76,7 @@
                       (t 0))))
     (mod (* id-num 137) 360)))
 
-(defmacro layout (title class theme &body body)
+(defmacro layout (title class prefs &body body)
   `(cl-who:with-html-output-to-string (s nil :prologue "<!DOCTYPE html>" :indent t)
      (:html
       (:head
@@ -84,7 +86,10 @@
        (:link :rel "manifest" :href "/manifest.json")
        (:link :rel "icon" :href "/static/favicon.ico" :type "image/png")
        (:link :rel "stylesheet"
-              :href (format nil "/static/styles/themes/~a.css" (or ,theme "default"))
+              :href (format nil "/static/styles/themes/~a.css" (or (preferences-theme ,prefs) "default"))
+              :type "text/css")
+       (:link :rel "stylesheet"
+              :href (format nil "/static/styles/syntax/~a.css" (or (preferences-syntax-theme ,prefs) "simple"))
               :type "text/css")
        (:script "if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
@@ -122,7 +127,7 @@ function validatePostForm(form, errorId) {
 
 (defun render-error-page (error-message &optional (prefs *preferences*))
   "Renders an HTML error page displaying the given ERROR-MESSAGE, using the specified layout PREFS."
-  (layout "Error - SchemeBBS" "error-page" (preferences-theme prefs)
+  (layout "Error - SchemeBBS" "error-page" prefs
     (cl-who:with-html-output-to-string (s nil :indent t)
       (:h1 "Error")
       (:hr)
@@ -259,6 +264,18 @@ function validatePostForm(form, errorId) {
     (setf s (cl-ppcre:regex-replace-all "&lt;" s "<"))
     (setf s (cl-ppcre:regex-replace-all "&gt;" s ">"))
     (setf s (cl-ppcre:regex-replace-all "&#39;" s "'"))
+    (setf s (cl-ppcre:regex-replace-all "&#039;" s "'"))
+    (setf s (cl-ppcre:regex-replace-all "&apos;" s "'"))
+    (setf s (cl-ppcre:regex-replace-all "&#[xX]([0-9a-fA-F]+);" s
+                                        (lambda (match-string hex-str)
+                                          (declare (ignore match-string))
+                                          (string (code-char (parse-integer hex-str :radix 16))))
+                                        :simple-calls t))
+    (setf s (cl-ppcre:regex-replace-all "&#([0-9]+);" s
+                                        (lambda (match-string dec-str)
+                                          (declare (ignore match-string))
+                                          (string (code-char (parse-integer dec-str :radix 10))))
+                                        :simple-calls t))
     (setf s (cl-ppcre:regex-replace-all "&amp;" s "&"))
     s))
 
@@ -490,7 +507,7 @@ function validatePostForm(form, errorId) {
 (defun render-index (board threads &optional (prefs *preferences*))
   "Renders the board index (frontpage) HTML with the list of active THREADS
 and the new thread form, using layout PREFS."
-  (layout (format nil "/~a/ - SchemeBBS" board) nil (preferences-theme prefs)
+  (layout (format nil "/~a/ - SchemeBBS" board) nil prefs
     (cl-who:with-html-output-to-string (s nil :indent t)
       (cl-who:str (render-board-name board))
       (cl-who:str (render-menu board "front"))
@@ -505,7 +522,7 @@ and the new thread form, using layout PREFS."
 
 (defun render-list (board threads &optional (prefs *preferences*))
   "Renders the board thread-list HTML page, showing all THREADS in tabular format, using layout PREFS."
-  (layout (format nil "/~a/ - SchemeBBS" board) nil (preferences-theme prefs)
+  (layout (format nil "/~a/ - SchemeBBS" board) nil prefs
     (cl-who:with-html-output-to-string (s nil :indent t)
       (cl-who:str (render-board-name board))
       (cl-who:str (render-menu board "list"))
@@ -563,7 +580,7 @@ optionally filtered by RANGE-STRING, using layout PREFS."
                                              do (setf (gethash id allowed-ids) t))))))))
                             (lambda (id) (gethash id allowed-ids)))
                           (lambda (id) (declare (ignore id)) t))))
-    (layout (format nil "/~a/ - SchemeBBS" board) "thread" theme
+    (layout (format nil "/~a/ - SchemeBBS" board) "thread" prefs
       (cl-who:with-html-output-to-string (s nil :indent t)
         (cl-who:str (render-board-name board))
         (cl-who:str (render-menu board "thread"))
@@ -616,11 +633,12 @@ stylesheet THEME, default-board and search configuration."
                                paths)
                        #'string<))
          (theme (preferences-theme prefs))
+         (syntax-theme (preferences-syntax-theme prefs))
          (default-board (preferences-default-board prefs))
          (search-hide-input (preferences-search-hide-input prefs))
          (search-local-only (preferences-search-local-only prefs))
          (search-position (preferences-search-position prefs)))
-    (layout (format nil "/~a/ - Preferences" board) "preferences" theme
+    (layout (format nil "/~a/ - Preferences" board) "preferences" prefs
       (cl-who:with-html-output-to-string (s nil :indent t)
         (cl-who:str (render-board-name board))
         (cl-who:str (render-menu board "preferences"))
@@ -640,6 +658,20 @@ stylesheet THEME, default-board and search configuration."
                                               :value item
                                               :checked (and theme (string= theme item))
                                               :onchange "updateThemePreview(this.value)")
+                                      (:span :class "theme-option-text" (cl-who:str item)))))))
+
+               (:div :style "margin-bottom: 2em;"
+                     (:h3 :style "margin-bottom: 0.5em;" "Syntax Theme")
+                     (:p :style "color: #555; font-size: 0.9em; margin-bottom: 0.8em;"
+                         "Choose syntax highlighting color scheme for Lisp code.")
+                     (:div :class "syntax-theme-selector-container"
+                           (dolist (item '("simple" "colorful"))
+                             (cl-who:htm
+                              (:label :class "theme-option-label" :style "margin-right: 15px;"
+                                      (:input :type "radio"
+                                              :name "syntax_theme"
+                                              :value item
+                                              :checked (and syntax-theme (string= syntax-theme item)))
                                       (:span :class "theme-option-text" (cl-who:str item)))))))
 
                (:div :style "margin-bottom: 2em;"
@@ -716,7 +748,7 @@ function updateThemePreview(themeValue) {
 (defun render-moderation (boards &optional board threads thread comments (prefs *preferences*) headline)
   "Renders the admin/moderation control panel HTML page showing BOARDS and allowing deletions/edits."
   (let ((theme (preferences-theme prefs)))
-    (layout "cl-bbs Moderation Panel" "moderation" theme
+    (layout "cl-bbs Moderation Panel" "moderation" prefs
       (cl-who:with-html-output-to-string (s nil :indent t)
         (:h1 "Moderation Panel")
         (:p (:a :href "/" "Back to Home"))
@@ -859,7 +891,7 @@ function updateThemePreview(themeValue) {
 (defun render-search-results (query results &optional (prefs *preferences*))
   "Renders the search results page HTML, showing matching posts for the given QUERY, using layout PREFS."
   (let ((theme (preferences-theme prefs)))
-    (layout (format nil "Search: ~a - SchemeBBS" query) "search-results" theme
+    (layout (format nil "Search: ~a - SchemeBBS" query) "search-results" prefs
       (cl-who:with-html-output-to-string (s nil :indent t)
         (:h1 "Search Results")
         (:p :style "margin: 0.5em 2%;"
@@ -911,7 +943,7 @@ function updateThemePreview(themeValue) {
   (let ((theme (preferences-theme prefs)))
     (layout (if board (format nil "/~a/ - Lisp Playground" board) "Lisp Playground")
             "playground-page"
-            theme
+            prefs
       (cl-who:with-html-output-to-string (s nil :indent t)
         (when board
           (cl-who:htm (cl-who:str (render-menu board "playground"))))

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -374,10 +374,11 @@ function validatePostForm(form, errorId) {
                               (raw-code (unescape-html escaped-code))
                               (colorized-code (handler-case (colorize:html-colorization :common-lisp raw-code)
                                                 (error () (cl-who:escape-string raw-code)))))
-                         ;; Note: colorize already wraps the result in <span class="..."><span class="paren1">...</span></span>
-                         ;; We wrap it in <pre class="lisp-code-block"> but keep a data-raw-code attribute or just use content for JS execution.
-                         ;; JSCL needs the raw text. To avoid JSCL trying to parse HTML, we'll embed the raw code in a hidden div,
-                         ;; or rely on JS `textContent` which extracts raw text from nested HTML elements. `textContent` works well.
+                         ;; Note: colorize already wraps the result in <span class="..."><span class="paren1">...
+                         ;; We wrap it in <pre class="lisp-code-block"> but keep a data-raw-code attribute
+                         ;; or just use content for JS execution. JSCL needs the raw text. To avoid JSCL trying
+                         ;; to parse HTML, we'll embed the raw code in a hidden div, or rely on JS `textContent`
+                         ;; which extracts raw text from nested HTML elements. `textContent` works well.
                          (format nil "</p><pre class=\"lisp-code-block\">~a</pre><p>" colorized-code))
                        (format nil "</p><pre>~a</pre><p>" content))))
                :simple-calls t))))
@@ -804,14 +805,16 @@ function updateThemePreview(themeValue) {
                                                                            "to delete this thread?');")))
                                       (unless (string-equal board "shame")
                                         (cl-who:htm
-                                         (:form :action "/admin/action" :method "POST" :style "display:inline; margin-left: 5px;"
+                                         (:form :action "/admin/action" :method "POST"
+                                                :style "display:inline; margin-left: 5px;"
                                                 (:input :type "hidden" :name "action" :value "shame-thread")
                                                 (:input :type "hidden" :name "board" :value board)
                                                 (:input :type "hidden" :name "thread" :value tid)
                                                 (:input :type "submit" :value "Shame" :class "shame-button"
                                                         :onclick (concatenate 'string
                                                                               "return confirm('Are you sure you want "
-                                                                              "to move this thread to the shame board?');")))))))))))))
+                                                                              "to move this thread to the shame "
+                                                                              "board?');")))))))))))))
              (cl-who:htm (:p "No threads found on this board.")))))
       (when (and board thread)
         (cl-who:htm
@@ -926,16 +929,20 @@ function updateThemePreview(themeValue) {
                              (:option :value "fib" "Fibonacci Numbers")
                              (:option :value "loop" "Loop Macro")
                              (:option :value "clos" "Common Lisp Object System (CLOS)")))
-              (:div :id "example-data-hello" :style "display:none;" (cl-who:str (colorize:html-colorization :common-lisp "(format t \"Hello, World!~%\")")))
-              (:div :id "example-data-fib" :style "display:none;" (cl-who:str (colorize:html-colorization :common-lisp "(defun fib (n)
+              (:div :id "example-data-hello" :style "display:none;"
+                    (cl-who:str (colorize:html-colorization :common-lisp "(format t \"Hello, World!~%\")")))
+              (:div :id "example-data-fib" :style "display:none;"
+                    (cl-who:str (colorize:html-colorization :common-lisp "(defun fib (n)
   (if (< n 2)
       n
       (+ (fib (- n 1)) (fib (- n 2)))))
 
 (format t \"Fibonacci of 10 is: ~a~%\" (fib 10))")))
-              (:div :id "example-data-loop" :style "display:none;" (cl-who:str (colorize:html-colorization :common-lisp "(loop for x from 1 to 5
+              (:div :id "example-data-loop" :style "display:none;"
+                    (cl-who:str (colorize:html-colorization :common-lisp "(loop for x from 1 to 5
       do (format t \"Square of ~d is ~d~%\" x (* x x)))")))
-              (:div :id "example-data-clos" :style "display:none;" (cl-who:str (colorize:html-colorization :common-lisp "(defclass person ()
+              (:div :id "example-data-clos" :style "display:none;"
+                    (cl-who:str (colorize:html-colorization :common-lisp "(defclass person ()
   ((name :accessor person-name :initarg :name)
    (age :accessor person-age :initarg :age)))
 
@@ -950,14 +957,28 @@ function updateThemePreview(themeValue) {
                     :class "lisp-code-block"
                     :contenteditable "true"
                     :spellcheck "false"
-                    :style "min-height: 200px; width: 96%; max-width: 800px; font-family: monospace; font-size: 1.1em; padding: 10px; border: 1px solid currentColor; background: transparent; color: inherit; margin-bottom: 1em; outline: none; overflow: auto; white-space: pre-wrap;"
+                    :style (concatenate 'string
+                                        "min-height: 200px; width: 96%; max-width: 800px; "
+                                        "font-family: monospace; font-size: 1.1em; padding: 10px; "
+                                        "border: 1px solid currentColor; background: transparent; "
+                                        "color: inherit; margin-bottom: 1em; outline: none; "
+                                        "overflow: auto; white-space: pre-wrap;")
                     "")
               (:div :style "display: flex; gap: 10px; margin-bottom: 1em;"
-                    (:button :id "playground-run" :style "padding: 6px 15px; font-size: 1em; cursor: pointer; font-weight: bold;" "Run Code")
-                    (:button :id "playground-clear" :style "padding: 6px 15px; font-size: 1em; cursor: pointer;" "Clear Output"))
+                    (:button :id "playground-run"
+                             :style "padding: 6px 15px; font-size: 1em; cursor: pointer; font-weight: bold;"
+                             "Run Code")
+                    (:button :id "playground-clear"
+                             :style "padding: 6px 15px; font-size: 1em; cursor: pointer;"
+                             "Clear Output"))
               (:h3 "Output Console")
               (:pre :id "playground-output"
-                    :style "display: none; padding: 10px; width: 96%; max-width: 800px; border: 1px dashed currentColor; background-color: rgba(128, 128, 128, 0.05); white-space: pre-wrap; word-break: break-all; font-family: monospace; font-size: 1.1em; line-height: 1.4em;"
+                    :style (concatenate 'string
+                                        "display: none; padding: 10px; width: 96%; max-width: 800px; "
+                                        "border: 1px dashed currentColor; "
+                                        "background-color: rgba(128, 128, 128, 0.05); white-space: pre-wrap; "
+                                        "word-break: break-all; font-family: monospace; font-size: 1.1em; "
+                                        "line-height: 1.4em;")
                     ""))
         (:hr)
         (cl-who:str (render-footer-html))))))

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -15,6 +15,7 @@
            #:render-moderation
            #:render-error-page
            #:render-search-results
+           #:render-playground
            #:preferences
            #:make-preferences
            #:preferences-theme
@@ -108,7 +109,8 @@ function validatePostForm(form, errorId) {
   }
   return true;
 }
-"))
+")
+       (:script :src "/static/jscl-snippets.js" :defer t))
       (:body :class ,class
              (cl-who:str (render-boards-header))
              (:hr)
@@ -140,7 +142,8 @@ function validatePostForm(form, errorId) {
        (not (uiop:string-prefix-p "/admin" path))
        (not (uiop:string-prefix-p "/about" path))
        (not (uiop:string-prefix-p "/sw.js" path))
-       (not (uiop:string-prefix-p "/manifest.json" path))))
+       (not (uiop:string-prefix-p "/manifest.json" path))
+       (not (uiop:string-prefix-p "/playground" path))))
 
 (defun get-current-board-from-path (path)
   "Extracts the board name from the request PATH."
@@ -212,15 +215,19 @@ function validatePostForm(form, errorId) {
             (cl-who:str "front")
             (cl-who:htm (:a :href (format nil "/~a" board) "front")))
         " - "
-        (if (string= selected "thread list")
-            (cl-who:str "thread list")
-            (cl-who:htm (:a :href (format nil "/~a/list" board) "thread list")))
+        (if (string= selected "list")
+            (cl-who:str "list")
+            (cl-who:htm (:a :href (format nil "/~a/list" board) "list")))
         " - "
         (if (string= selected "front")
-            (cl-who:htm (:a :href "#newthread" "new thread"))
-            (cl-who:htm (:a :href (format nil "/~a#newthread" board) "new thread")))
+            (cl-who:htm (:a :href "#newthread" "new"))
+            (cl-who:htm (:a :href (format nil "/~a#newthread" board) "new")))
         " - "
         (:a :href (format nil "/~a/preferences" board) "preferences")
+        " - "
+        (if (string= selected "playground")
+            (cl-who:str "λ")
+            (cl-who:htm (:a :href (format nil "/~a/playground" board) "λ")))
         " - "
         (:a :href "/index.html" "?"))))
 
@@ -245,6 +252,15 @@ function validatePostForm(form, errorId) {
                  (:p (:input :type "text" :name "name" :style "display:none")
                      (:input :type "text" :name "message" :style "display:none")
                      (:input :type "submit" :value "Post"))))))
+
+(defun unescape-html (string)
+  (let ((s string))
+    (setf s (cl-ppcre:regex-replace-all "&quot;" s "\""))
+    (setf s (cl-ppcre:regex-replace-all "&lt;" s "<"))
+    (setf s (cl-ppcre:regex-replace-all "&gt;" s ">"))
+    (setf s (cl-ppcre:regex-replace-all "&#39;" s "'"))
+    (setf s (cl-ppcre:regex-replace-all "&amp;" s "&"))
+    s))
 
 (defun format-text (text &optional thread-id)
   (let* ((escaped (cl-who:escape-string text))
@@ -350,7 +366,20 @@ function validatePostForm(form, errorId) {
                processed
                (lambda (match-string &optional regs)
                  (declare (ignore match-string regs))
-                 (format nil "</p><pre>~a</pre><p>" content))
+                 (multiple-value-bind (match-start match-end reg-starts reg-ends)
+                     (cl-ppcre:scan "^(?i)(lisp|cl|common-lisp)\\r?\\n" content)
+                   (declare (ignore reg-starts reg-ends))
+                   (if match-start
+                       (let* ((escaped-code (subseq content match-end))
+                              (raw-code (unescape-html escaped-code))
+                              (colorized-code (handler-case (colorize:html-colorization :common-lisp raw-code)
+                                                (error () (cl-who:escape-string raw-code)))))
+                         ;; Note: colorize already wraps the result in <span class="..."><span class="paren1">...</span></span>
+                         ;; We wrap it in <pre class="lisp-code-block"> but keep a data-raw-code attribute or just use content for JS execution.
+                         ;; JSCL needs the raw text. To avoid JSCL trying to parse HTML, we'll embed the raw code in a hidden div,
+                         ;; or rely on JS `textContent` which extracts raw text from nested HTML elements. `textContent` works well.
+                         (format nil "</p><pre class=\"lisp-code-block\">~a</pre><p>" colorized-code))
+                       (format nil "</p><pre>~a</pre><p>" content))))
                :simple-calls t))))
     (setf processed
           (cl-ppcre:regex-replace-all
@@ -478,7 +507,7 @@ and the new thread form, using layout PREFS."
   (layout (format nil "/~a/ - SchemeBBS" board) nil (preferences-theme prefs)
     (cl-who:with-html-output-to-string (s nil :indent t)
       (cl-who:str (render-board-name board))
-      (cl-who:str (render-menu board "thread list"))
+      (cl-who:str (render-menu board "list"))
       (:hr)
       (:table :summary "Thread list"
               (:thead (:tr (:th "#") (:th "headline") (:th "posts") (:th "last update")))
@@ -871,5 +900,64 @@ function updateThemePreview(themeValue) {
                             (:samp (cl-who:esc date)))
                        (:dd :style post-style
                             (cl-who:str (format-text content thread-id)))))))))
+        (:hr)
+        (cl-who:str (render-footer-html))))))
+
+(defun render-playground (&optional board (prefs *preferences*))
+  "Renders the interactive Common Lisp playground view."
+  (let ((theme (preferences-theme prefs)))
+    (layout (if board (format nil "/~a/ - Lisp Playground" board) "Lisp Playground")
+            "playground-page"
+            theme
+      (cl-who:with-html-output-to-string (s nil :indent t)
+        (when board
+          (cl-who:htm (cl-who:str (render-menu board "playground"))))
+        (:h2 "Common Lisp Playground")
+        (:p :style "margin: 0.5em 2%; font-size: 0.95em;"
+            "Write and execute Common Lisp code directly in your browser using "
+            (:a :href "https://github.com/jscl-project/jscl" :target "_blank" "JSCL")
+            ". Everything runs completely client-side in a sandboxed environment.")
+        (:div :class "playground-container" :style "margin: 1.5em 2%;"
+              (:div :style "margin-bottom: 1em; display: flex; gap: 10px; align-items: center; flex-wrap: wrap;"
+                    (:span "Load Example: ")
+                    (:select :id "playground-examples" :style "padding: 4px;"
+                             (:option :value "" "-- Select Example --")
+                             (:option :value "hello" "Hello World")
+                             (:option :value "fib" "Fibonacci Numbers")
+                             (:option :value "loop" "Loop Macro")
+                             (:option :value "clos" "Common Lisp Object System (CLOS)")))
+              (:div :id "example-data-hello" :style "display:none;" (cl-who:str (colorize:html-colorization :common-lisp "(format t \"Hello, World!~%\")")))
+              (:div :id "example-data-fib" :style "display:none;" (cl-who:str (colorize:html-colorization :common-lisp "(defun fib (n)
+  (if (< n 2)
+      n
+      (+ (fib (- n 1)) (fib (- n 2)))))
+
+(format t \"Fibonacci of 10 is: ~a~%\" (fib 10))")))
+              (:div :id "example-data-loop" :style "display:none;" (cl-who:str (colorize:html-colorization :common-lisp "(loop for x from 1 to 5
+      do (format t \"Square of ~d is ~d~%\" x (* x x)))")))
+              (:div :id "example-data-clos" :style "display:none;" (cl-who:str (colorize:html-colorization :common-lisp "(defclass person ()
+  ((name :accessor person-name :initarg :name)
+   (age :accessor person-age :initarg :age)))
+
+(defmethod introduce ((p person))
+  (format t \"Hi, I am ~a and I am ~a years old.~%\"
+          (person-name p)
+          (person-age p)))
+
+(let ((p (make-instance 'person :name \"Alice\" :age 30)))
+  (introduce p))")))
+              (:pre :id "playground-editor"
+                    :class "lisp-code-block"
+                    :contenteditable "true"
+                    :spellcheck "false"
+                    :style "min-height: 200px; width: 96%; max-width: 800px; font-family: monospace; font-size: 1.1em; padding: 10px; border: 1px solid currentColor; background: transparent; color: inherit; margin-bottom: 1em; outline: none; overflow: auto; white-space: pre-wrap;"
+                    "")
+              (:div :style "display: flex; gap: 10px; margin-bottom: 1em;"
+                    (:button :id "playground-run" :style "padding: 6px 15px; font-size: 1em; cursor: pointer; font-weight: bold;" "Run Code")
+                    (:button :id "playground-clear" :style "padding: 6px 15px; font-size: 1em; cursor: pointer;" "Clear Output"))
+              (:h3 "Output Console")
+              (:pre :id "playground-output"
+                    :style "display: none; padding: 10px; width: 96%; max-width: 800px; border: 1px dashed currentColor; background-color: rgba(128, 128, 128, 0.05); white-space: pre-wrap; word-break: break-all; font-family: monospace; font-size: 1.1em; line-height: 1.4em;"
+                    ""))
         (:hr)
         (cl-who:str (render-footer-html))))))

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -29,8 +29,8 @@
 (in-package :cl-bbs/views)
 
 ;; Initialize colorize and HyperSpec lookup paths safely
-(setf colorize:*debug* nil)
 (eval-when (:execute)
+  (setf colorize:*debug* nil)
   (handler-case
       (let* ((base-dir (asdf:system-source-directory :cl-bbs/server))
              (local-clhs-dir (and base-dir (merge-pathnames "data/HyperSpec/" base-dir)))

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -28,6 +28,13 @@
 
 (in-package :cl-bbs/views)
 
+;; Initialize colorize and HyperSpec lookup paths
+(setf colorize:*debug* nil)
+(setf clhs-lookup::*hyperspec-pathname* 
+      (merge-pathnames "data/HyperSpec/" (asdf:system-source-directory :cl-bbs/server)))
+(setf clhs-lookup::*hyperspec-map-file* 
+      (merge-pathnames "Data/Map_Sym.txt" clhs-lookup::*hyperspec-pathname*))
+
 (defstruct preferences
   (theme "default")
   (syntax-theme "simple")

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -28,12 +28,21 @@
 
 (in-package :cl-bbs/views)
 
-;; Initialize colorize and HyperSpec lookup paths
+;; Initialize colorize and HyperSpec lookup paths safely
 (setf colorize:*debug* nil)
-(setf clhs-lookup::*hyperspec-pathname* 
-      (merge-pathnames "data/HyperSpec/" (asdf:system-source-directory :cl-bbs/server)))
-(setf clhs-lookup::*hyperspec-map-file* 
-      (merge-pathnames "Data/Map_Sym.txt" clhs-lookup::*hyperspec-pathname*))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (handler-case
+      (let* ((base-dir (asdf:system-source-directory :cl-bbs/server))
+             (local-clhs-dir (and base-dir (merge-pathnames "data/HyperSpec/" base-dir)))
+             (local-map-file (and local-clhs-dir (merge-pathnames "Data/Map_Sym.txt" local-clhs-dir))))
+        (if (and local-map-file (probe-file local-map-file))
+            (progn
+              (setf clhs-lookup::*hyperspec-pathname* local-clhs-dir)
+              (setf clhs-lookup::*hyperspec-map-file* local-map-file))
+            (setf clhs-lookup::*hyperspec-map-file* #p"nonexistent-map-sym.txt")))
+    (error (e)
+      (declare (ignore e))
+      (setf clhs-lookup::*hyperspec-map-file* #p"nonexistent-map-sym.txt"))))
 
 (defstruct preferences
   (theme "default")

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -30,7 +30,7 @@
 
 ;; Initialize colorize and HyperSpec lookup paths safely
 (setf colorize:*debug* nil)
-(eval-when (:compile-toplevel :load-toplevel :execute)
+(eval-when (:load-toplevel :execute)
   (handler-case
       (let* ((base-dir (asdf:system-source-directory :cl-bbs/server))
              (local-clhs-dir (and base-dir (merge-pathnames "data/HyperSpec/" base-dir)))

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -28,22 +28,6 @@
 
 (in-package :cl-bbs/views)
 
-;; Initialize colorize and HyperSpec lookup paths safely
-(eval-when (:execute)
-  (setf colorize:*debug* nil)
-  (handler-case
-      (let* ((base-dir (asdf:system-source-directory :cl-bbs/server))
-             (local-clhs-dir (and base-dir (merge-pathnames "data/HyperSpec/" base-dir)))
-             (local-map-file (and local-clhs-dir (merge-pathnames "Data/Map_Sym.txt" local-clhs-dir))))
-        (if (and local-map-file (probe-file local-map-file))
-            (progn
-              (setf clhs-lookup::*hyperspec-pathname* local-clhs-dir)
-              (setf clhs-lookup::*hyperspec-map-file* local-map-file))
-            (setf clhs-lookup::*hyperspec-map-file* #p"nonexistent-map-sym.txt")))
-    (error (e)
-      (declare (ignore e))
-      (setf clhs-lookup::*hyperspec-map-file* #p"nonexistent-map-sym.txt"))))
-
 (defstruct preferences
   (theme "default")
   (syntax-theme "simple")
@@ -763,44 +747,43 @@ function updateThemePreview(themeValue) {
 
 (defun render-moderation (boards &optional board threads thread comments (prefs *preferences*) headline)
   "Renders the admin/moderation control panel HTML page showing BOARDS and allowing deletions/edits."
-  (let ((theme (preferences-theme prefs)))
-    (layout "cl-bbs Moderation Panel" "moderation" prefs
-      (cl-who:with-html-output-to-string (s nil :indent t)
-        (:h1 "Moderation Panel")
-        (:p (:a :href "/" "Back to Home"))
-        (:hr)
-        (:h2 "Boards")
-        (:ul
-         (dolist (b boards)
-           (cl-who:htm
-            (:li (:strong (:a :href (format nil "/admin?board=~a" b) (cl-who:esc b)))
-                 " &nbsp; "
-                 (:form :action "/admin/action" :method "POST" :style "display:inline;"
-                        (:input :type "hidden" :name "action" :value "delete-board")
-                        (:input :type "hidden" :name "board" :value b)
-                        (:input :type "submit" :value "Delete Board" :class "delete-button"
-                                :onclick (concatenate 'string
-                                                      "return confirm('Are you sure you want to "
-                                                      "delete the ENTIRE board? "
-                                                      "This cannot be undone.');")))))))
-        (:h2 "Create Board")
-        (:p "Enter a board name below to create a new board. Board names must be in "
-            (:strong "kebab-case")
-            " (only lowercase letters, numbers, and hyphens; no spaces or underlines).")
-        (:div :style "margin: 1em 0;"
-              (:form :action "/admin/action" :method "POST" :onsubmit "return validateCreateBoard()"
-                     (:input :type "hidden" :name "action" :value "create-board")
-                     (:input :type "text" :name "board" :id "new-board-name" :placeholder "board-name"
-                             :style "padding: 6px; font-size: 1em; border: 1px solid #bababa;
+  (layout "cl-bbs Moderation Panel" "moderation" prefs
+          (cl-who:with-html-output-to-string (s nil :indent t)
+            (:h1 "Moderation Panel")
+            (:p (:a :href "/" "Back to Home"))
+            (:hr)
+            (:h2 "Boards")
+            (:ul
+             (dolist (b boards)
+               (cl-who:htm
+                (:li (:strong (:a :href (format nil "/admin?board=~a" b) (cl-who:esc b)))
+                     " &nbsp; "
+                     (:form :action "/admin/action" :method "POST" :style "display:inline;"
+                            (:input :type "hidden" :name "action" :value "delete-board")
+                            (:input :type "hidden" :name "board" :value b)
+                            (:input :type "submit" :value "Delete Board" :class "delete-button"
+                                    :onclick (concatenate 'string
+                                                          "return confirm('Are you sure you want to "
+                                                          "delete the ENTIRE board? "
+                                                          "This cannot be undone.');")))))))
+            (:h2 "Create Board")
+            (:p "Enter a board name below to create a new board. Board names must be in "
+                (:strong "kebab-case")
+                " (only lowercase letters, numbers, and hyphens; no spaces or underlines).")
+            (:div :style "margin: 1em 0;"
+                  (:form :action "/admin/action" :method "POST" :onsubmit "return validateCreateBoard()"
+                         (:input :type "hidden" :name "action" :value "create-board")
+                         (:input :type "text" :name "board" :id "new-board-name" :placeholder "board-name"
+                                 :style "padding: 6px; font-size: 1em; border: 1px solid #bababa;
                                      border-radius: 4px; font-family: monospace;")
-                     " "
-                     (:input :type "submit" :value "Create Board"
-                             :style "padding: 6px 12px; font-size: 1em; background-color: #ededed;
+                         " "
+                         (:input :type "submit" :value "Create Board"
+                                 :style "padding: 6px 12px; font-size: 1em; background-color: #ededed;
                                      border: 1px solid #b5b5b5; border-radius: 4px; cursor: pointer;
                                      font-weight: bold;"))
-              (:p :id "board-error" :style "color: red; font-size: 0.9em; margin: 0.5em 0; display: none;"))
-        (:script :type "text/javascript"
-                 "function validateCreateBoard() {
+                  (:p :id "board-error" :style "color: red; font-size: 0.9em; margin: 0.5em 0; display: none;"))
+            (:script :type "text/javascript"
+                     "function validateCreateBoard() {
         const input = document.getElementById('new-board-name');
         const error = document.getElementById('board-error');
         const boardName = input.value.trim();
@@ -825,84 +808,88 @@ function updateThemePreview(themeValue) {
   error.style.display = 'none';
   return true;
 }")
-        (when board
-          (cl-who:htm
-           (:hr)
-           (:h2 (cl-who:fmt "Threads in /~a/" board))
-           (if threads
-               (cl-who:htm
-                (:table :border 1 :cellpadding 5
-                        (:thead (:tr (:th "ID") (:th "Headline") (:th "Date") (:th "Actions")))
-                      (:tbody
-                       (dolist (t-data threads)
-                         (let* ((tid (car t-data))
-                                (props (cdr t-data))
-                                (headline (cdr (assoc 'cl-bbs/models:headline props))))
-                           (cl-who:htm
-                            (:tr (:td (cl-who:str (format nil "~a" tid)))
-                                 (:td (:a :href (format nil "/admin?board=~a&thread=~a" board tid)
-                                          (cl-who:esc headline)))
-                                 (:td (cl-who:str (format nil "~a" (cdr (assoc 'cl-bbs/models:date props)))))
-                                 (:td (:form :action "/admin/action" :method "POST" :style "display:inline;"
-                                             (:input :type "hidden" :name "action" :value "delete-thread")
-                                             (:input :type "hidden" :name "board" :value board)
-                                             (:input :type "hidden" :name "thread" :value tid)
-                                             (:input :type "submit" :value "Delete Thread" :class "delete-button"
-                                                     :onclick (concatenate 'string
-                                                                           "return confirm('Are you sure you want "
-                                                                           "to delete this thread?');")))
-                                      (unless (string-equal board "shame")
-                                        (cl-who:htm
-                                         (:form :action "/admin/action" :method "POST"
-                                                :style "display:inline; margin-left: 5px;"
-                                                (:input :type "hidden" :name "action" :value "shame-thread")
-                                                (:input :type "hidden" :name "board" :value board)
-                                                (:input :type "hidden" :name "thread" :value tid)
-                                                (:input :type "submit" :value "Shame" :class "shame-button"
-                                                        :onclick (concatenate 'string
-                                                                              "return confirm('Are you sure you want "
-                                                                              "to move this thread to the shame "
-                                                                              "board?');")))))))))))))
-             (cl-who:htm (:p "No threads found on this board.")))))
-      (when (and board thread)
-        (cl-who:htm
-         (:hr)
-         (:h2 (cl-who:fmt "Comments in Thread #~a (~a)" thread board))
-         (if comments
-             (cl-who:htm
-              (:dl
-               (dolist (p comments)
-                 (let* ((pid (car p))
-                        (pdata (cdr p))
-                        (content (cdr (assoc 'cl-bbs/models:content pdata)))
-                        (date (cdr (assoc 'cl-bbs/models:date pdata))))
+            (when board
+              (cl-who:htm
+               (:hr)
+               (:h2 (cl-who:fmt "Threads in /~a/" board))
+               (if threads
                    (cl-who:htm
-                    (:dt "No." (cl-who:str (format nil "~a" pid)) " " (:samp (cl-who:esc date))
-                         " &nbsp; "
-                         (:form :action "/admin/action" :method "POST" :style "display:inline;"
-                                (:input :type "hidden" :name "action" :value "delete-comment")
-                                (:input :type "hidden" :name "board" :value board)
-                                (:input :type "hidden" :name "thread" :value thread)
-                                (:input :type "hidden" :name "comment" :value pid)
-                                (:input :type "submit" :value "Delete Comment" :class "delete-button"
-                                        :onclick "return confirm('Are you sure you want to delete this comment?');")))
-                    (:dd
-                     (:div :class "comment-preview"
-                           (cl-who:str (format-text content thread)))
-                     (:form :action "/admin/action" :method "POST" :style "margin-top: 0.5em;"
-                            (:input :type "hidden" :name "action" :value "edit-comment")
-                            (:input :type "hidden" :name "board" :value board)
-                            (:input :type "hidden" :name "thread" :value thread)
-                            (:input :type "hidden" :name "comment" :value pid)
-                            (when (and (= pid 1) headline)
-                              (cl-who:htm
-                               (:p (:label :for "headline" "Thread Headline: ")
-                                   (:br)
-                                   (:input :type "text" :name "headline" :id "headline" :size 60 :value headline))))
-                            (:textarea :name "content" :rows 3 :cols 60 (cl-who:str content))
-                            (:br)
-                            (:input :type "submit" :value "Save Changes"))))))))
-             (cl-who:htm (:p "No comments found.")))))))))
+                    (:table :border 1 :cellpadding 5
+                            (:thead (:tr (:th "ID") (:th "Headline") (:th "Date") (:th "Actions")))
+                            (:tbody
+                             (dolist (t-data threads)
+                               (let* ((tid (car t-data))
+                                      (props (cdr t-data))
+                                      (headline (cdr (assoc 'cl-bbs/models:headline props))))
+                                 (cl-who:htm
+                                  (:tr (:td (cl-who:str (format nil "~a" tid)))
+                                       (:td (:a :href (format nil "/admin?board=~a&thread=~a" board tid)
+                                                (cl-who:esc headline)))
+                                       (:td (cl-who:str (format nil "~a" (cdr (assoc 'cl-bbs/models:date props)))))
+                                       (:td (:form :action "/admin/action" :method "POST" :style "display:inline;"
+                                                   (:input :type "hidden" :name "action" :value "delete-thread")
+                                                   (:input :type "hidden" :name "board" :value board)
+                                                   (:input :type "hidden" :name "thread" :value tid)
+                                                   (:input :type "submit" :value "Delete Thread" :class "delete-button"
+                                                           :onclick
+                                                           (concatenate 'string
+                                                                        "return confirm('Are you sure you want "
+                                                                        "to delete this thread?');")))
+                                            (unless (string-equal board "shame")
+                                              (cl-who:htm
+                                               (:form :action "/admin/action" :method "POST"
+                                                      :style "display:inline; margin-left: 5px;"
+                                                      (:input :type "hidden" :name "action" :value "shame-thread")
+                                                      (:input :type "hidden" :name "board" :value board)
+                                                      (:input :type "hidden" :name "thread" :value tid)
+                                                      (:input :type "submit" :value "Shame" :class "shame-button"
+                                                              :onclick
+                                                              (concatenate 'string
+                                                                           "return confirm('Are you sure you want "
+                                                                           "to move this thread to the shame "
+                                                                           "board?');")))))))))))))
+                   (cl-who:htm (:p "No threads found on this board.")))))
+            (when (and board thread)
+              (cl-who:htm
+               (:hr)
+               (:h2 (cl-who:fmt "Comments in Thread #~a (~a)" thread board))
+               (if comments
+                   (cl-who:htm
+                    (:dl
+                     (dolist (p comments)
+                       (let* ((pid (car p))
+                              (pdata (cdr p))
+                              (content (cdr (assoc 'cl-bbs/models:content pdata)))
+                              (date (cdr (assoc 'cl-bbs/models:date pdata))))
+                         (cl-who:htm
+                          (:dt "No." (cl-who:str (format nil "~a" pid)) " " (:samp (cl-who:esc date))
+                               " &nbsp; "
+                               (:form :action "/admin/action" :method "POST" :style "display:inline;"
+                                      (:input :type "hidden" :name "action" :value "delete-comment")
+                                      (:input :type "hidden" :name "board" :value board)
+                                      (:input :type "hidden" :name "thread" :value thread)
+                                      (:input :type "hidden" :name "comment" :value pid)
+                                      (:input :type "submit" :value "Delete Comment" :class "delete-button"
+                                              :onclick
+                                              "return confirm('Are you sure you want to delete this comment?');")))
+                          (:dd
+                           (:div :class "comment-preview"
+                                 (cl-who:str (format-text content thread)))
+                           (:form :action "/admin/action" :method "POST" :style "margin-top: 0.5em;"
+                                  (:input :type "hidden" :name "action" :value "edit-comment")
+                                  (:input :type "hidden" :name "board" :value board)
+                                  (:input :type "hidden" :name "thread" :value thread)
+                                  (:input :type "hidden" :name "comment" :value pid)
+                                  (when (and (= pid 1) headline)
+                                    (cl-who:htm
+                                     (:p (:label :for "headline" "Thread Headline: ")
+                                         (:br)
+                                         (:input :type "text" :name "headline" :id "headline"
+                                                 :size 60 :value headline))))
+                                  (:textarea :name "content" :rows 3 :cols 60 (cl-who:str content))
+                                  (:br)
+                                  (:input :type "submit" :value "Save Changes"))))))))
+                   (cl-who:htm (:p "No comments found."))))))))
 
 (defun render-search-results (query results &optional (prefs *preferences*))
   "Renders the search results page HTML, showing matching posts for the given QUERY, using layout PREFS."
@@ -956,41 +943,40 @@ function updateThemePreview(themeValue) {
 
 (defun render-playground (&optional board (prefs *preferences*))
   "Renders the interactive Common Lisp playground view."
-  (let ((theme (preferences-theme prefs)))
-    (layout (if board (format nil "/~a/ - Lisp Playground" board) "Lisp Playground")
-            "playground-page"
-            prefs
-      (cl-who:with-html-output-to-string (s nil :indent t)
-        (when board
-          (cl-who:htm (cl-who:str (render-menu board "playground"))))
-        (:h2 "Common Lisp Playground")
-        (:p :style "margin: 0.5em 2%; font-size: 0.95em;"
-            "Write and execute Common Lisp code directly in your browser using "
-            (:a :href "https://github.com/jscl-project/jscl" :target "_blank" "JSCL")
-            ". Everything runs completely client-side in a sandboxed environment.")
-        (:div :class "playground-container" :style "margin: 1.5em 2%;"
-              (:div :style "margin-bottom: 1em; display: flex; gap: 10px; align-items: center; flex-wrap: wrap;"
-                    (:span "Load Example: ")
-                    (:select :id "playground-examples" :style "padding: 4px;"
-                             (:option :value "" "-- Select Example --")
-                             (:option :value "hello" "Hello World")
-                             (:option :value "fib" "Fibonacci Numbers")
-                             (:option :value "loop" "Loop Macro")
-                             (:option :value "clos" "Common Lisp Object System (CLOS)")))
-              (:div :id "example-data-hello" :style "display:none;"
-                    (cl-who:str (colorize:html-colorization :common-lisp "(format t \"Hello, World!~%\")")))
-              (:div :id "example-data-fib" :style "display:none;"
-                    (cl-who:str (colorize:html-colorization :common-lisp "(defun fib (n)
+  (layout (if board (format nil "/~a/ - Lisp Playground" board) "Lisp Playground")
+          "playground-page"
+          prefs
+          (cl-who:with-html-output-to-string (s nil :indent t)
+            (when board
+              (cl-who:htm (cl-who:str (render-menu board "playground"))))
+            (:h2 "Common Lisp Playground")
+            (:p :style "margin: 0.5em 2%; font-size: 0.95em;"
+                "Write and execute Common Lisp code directly in your browser using "
+                (:a :href "https://github.com/jscl-project/jscl" :target "_blank" "JSCL")
+                ". Everything runs completely client-side in a sandboxed environment.")
+            (:div :class "playground-container" :style "margin: 1.5em 2%;"
+                  (:div :style "margin-bottom: 1em; display: flex; gap: 10px; align-items: center; flex-wrap: wrap;"
+                        (:span "Load Example: ")
+                        (:select :id "playground-examples" :style "padding: 4px;"
+                                 (:option :value "" "-- Select Example --")
+                                 (:option :value "hello" "Hello World")
+                                 (:option :value "fib" "Fibonacci Numbers")
+                                 (:option :value "loop" "Loop Macro")
+                                 (:option :value "clos" "Common Lisp Object System (CLOS)")))
+                  (:div :id "example-data-hello" :style "display:none;"
+                        (cl-who:str (colorize:html-colorization :common-lisp "(format t \"Hello, World!~%\")")))
+                  (:div :id "example-data-fib" :style "display:none;"
+                        (cl-who:str (colorize:html-colorization :common-lisp "(defun fib (n)
   (if (< n 2)
       n
       (+ (fib (- n 1)) (fib (- n 2)))))
 
 (format t \"Fibonacci of 10 is: ~a~%\" (fib 10))")))
-              (:div :id "example-data-loop" :style "display:none;"
-                    (cl-who:str (colorize:html-colorization :common-lisp "(loop for x from 1 to 5
+                  (:div :id "example-data-loop" :style "display:none;"
+                        (cl-who:str (colorize:html-colorization :common-lisp "(loop for x from 1 to 5
       do (format t \"Square of ~d is ~d~%\" x (* x x)))")))
-              (:div :id "example-data-clos" :style "display:none;"
-                    (cl-who:str (colorize:html-colorization :common-lisp "(defclass person ()
+                  (:div :id "example-data-clos" :style "display:none;"
+                        (cl-who:str (colorize:html-colorization :common-lisp "(defclass person ()
   ((name :accessor person-name :initarg :name)
    (age :accessor person-age :initarg :age)))
 
@@ -1001,32 +987,32 @@ function updateThemePreview(themeValue) {
 
 (let ((p (make-instance 'person :name \"Alice\" :age 30)))
   (introduce p))")))
-              (:pre :id "playground-editor"
-                    :class "lisp-code-block"
-                    :contenteditable "true"
-                    :spellcheck "false"
-                    :style (concatenate 'string
-                                        "min-height: 200px; width: 96%; max-width: 800px; "
-                                        "font-family: monospace; font-size: 1.1em; padding: 10px; "
-                                        "border: 1px solid currentColor; background: transparent; "
-                                        "color: inherit; margin-bottom: 1em; outline: none; "
-                                        "overflow: auto; white-space: pre-wrap;")
-                    "")
-              (:div :style "display: flex; gap: 10px; margin-bottom: 1em;"
-                    (:button :id "playground-run"
-                             :style "padding: 6px 15px; font-size: 1em; cursor: pointer; font-weight: bold;"
-                             "Run Code")
-                    (:button :id "playground-clear"
-                             :style "padding: 6px 15px; font-size: 1em; cursor: pointer;"
-                             "Clear Output"))
-              (:h3 "Output Console")
-              (:pre :id "playground-output"
-                    :style (concatenate 'string
-                                        "display: none; padding: 10px; width: 96%; max-width: 800px; "
-                                        "border: 1px dashed currentColor; "
-                                        "background-color: rgba(128, 128, 128, 0.05); white-space: pre-wrap; "
-                                        "word-break: break-all; font-family: monospace; font-size: 1.1em; "
-                                        "line-height: 1.4em;")
-                    ""))
-        (:hr)
-        (cl-who:str (render-footer-html))))))
+                  (:pre :id "playground-editor"
+                        :class "lisp-code-block"
+                        :contenteditable "true"
+                        :spellcheck "false"
+                        :style (concatenate 'string
+                                            "min-height: 200px; width: 96%; max-width: 800px; "
+                                            "font-family: monospace; font-size: 1.1em; padding: 10px; "
+                                            "border: 1px solid currentColor; background: transparent; "
+                                            "color: inherit; margin-bottom: 1em; outline: none; "
+                                            "overflow: auto; white-space: pre-wrap;")
+                        "")
+                  (:div :style "display: flex; gap: 10px; margin-bottom: 1em;"
+                        (:button :id "playground-run"
+                                 :style "padding: 6px 15px; font-size: 1em; cursor: pointer; font-weight: bold;"
+                                 "Run Code")
+                        (:button :id "playground-clear"
+                                 :style "padding: 6px 15px; font-size: 1em; cursor: pointer;"
+                                 "Clear Output"))
+                  (:h3 "Output Console")
+                  (:pre :id "playground-output"
+                        :style (concatenate 'string
+                                            "display: none; padding: 10px; width: 96%; max-width: 800px; "
+                                            "border: 1px dashed currentColor; "
+                                            "background-color: rgba(128, 128, 128, 0.05); white-space: pre-wrap; "
+                                            "word-break: break-all; font-family: monospace; font-size: 1.1em; "
+                                            "line-height: 1.4em;")
+                        ""))
+            (:hr)
+            (cl-who:str (render-footer-html)))))

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -317,13 +317,13 @@ function validatePostForm(form, errorId) {
            :simple-calls t))
     (setf processed
           (cl-ppcre:regex-replace-all
-           "https?://[\\w\\-\\.\\/\\?\\=\\&\\%\\#\\+]+"
+           "https?://[\\w\\-\\.\\/\\?\\=\\&\\%#\\+]+"
            processed
            "<a href=\"\\&\" target=\"_blank\">\\&</a>"))
     (setf processed
           (cl-ppcre:regex-replace-all
            (concatenate 'string
-                        "<a href=\"(https?://[\\w\\-\\.\\/\\?\\=\\&\\%\\#\\+]+"
+                        "<a href=\"(https?://[\\w\\-\\.\\/\\?\\=\\&\\%#\\+]+"
                         "\\.(?:png|jpg|jpeg|gif|webp|bmp))\" "
                         "target=\"_blank\">.*?</a>")
            processed
@@ -334,7 +334,7 @@ function validatePostForm(form, errorId) {
                         "alt=\"preview\" /></a><br />")))
     (setf processed
           (cl-ppcre:regex-replace-all
-           "image\\+<a href=\"(https?://[\\w\\-\\.\\/\\?\\=\\&\\%\\#\\+]+)\" target=\"_blank\">.*?</a>"
+           "image\\+<a href=\"(https?://[\\w\\-\\.\\/\\?\\=\\&\\%#\\+]+)\" target=\"_blank\">.*?</a>"
            processed
            (concatenate 'string
                         "<br /><a href=\"\\1\" target=\"_blank\">"

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -46,7 +46,9 @@
 <TD><PRE>;;;This is a block of code
 (lambda (h)
   ((lambda (f) (f f))
-   (lambda (f) (h (lambda (x) ((f f) x))))))</PRE></TD></TR></TBODY></TABLE>
+   (lambda (f) (h (lambda (x) ((f f) x))))))</PRE></TD></TR>
+<TR><TD><KBD>```lisp<BR>;;;Executable snippet<BR>(format t "Hello")<BR>```</KBD></TD>
+<TD><PRE class="lisp-code-block"><SPAN class=""><SPAN class="paren1">(<SPAN class="">format t <SPAN class="string">"Hello"</SPAN></SPAN>)</SPAN></SPAN></PRE><P style="font-size: 0.85em; font-style: italic;">Renders as a syntax-highlighted, client-side executable Common Lisp snippet via JSCL. You can also try out the <B>interactive Lisp Playground</B> by clicking the <B>λ</B> link in the navigation menu!</P></TD></TR></TBODY></TABLE>
 
 <H2>Source Code</H2>
 <P>Check the refactored Common Lisp port of cl-bbs at <A href="https://github.com/ryukinix/cl-bbs">github</A>. This version is fully refactored, robustly tested, and packaged with local sandbox package locks. You can also view the original MIT Scheme draft of SchemeBBS at <A href="https://github.com/alyssa-p-hacker/SchemeBBS">SchemeBBS</A>.</P>

--- a/src/static/jscl-snippets.js
+++ b/src/static/jscl-snippets.js
@@ -102,6 +102,21 @@ function initInlineSnippets() {
         block.style.padding = '';
         editBtn.textContent = 'Edit';
         isEditing = false;
+
+        // Fetch colorized version from backend API
+        const code = block.textContent;
+        fetch('/api/colorize', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          body: 'code=' + encodeURIComponent(code)
+        })
+        .then(response => response.text())
+        .then(html => {
+          block.innerHTML = html;
+        })
+        .catch(err => console.error("Failed to colorize snippet:", err));
       }
     });
 
@@ -258,6 +273,21 @@ ${code}
 
         outputPanel.textContent = displayResult;
         outputPanel.style.color = '';
+
+        // Dynamically update the editor syntax highlighting using backend colorize API
+        fetch('/api/colorize', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          body: 'code=' + encodeURIComponent(code)
+        })
+        .then(response => response.text())
+        .then(html => {
+          editor.innerHTML = html;
+        })
+        .catch(err => console.error("Failed to colorize playground code:", err));
+
       } catch (err) {
         outputPanel.textContent = `Error: ${err.message || err}`;
         outputPanel.style.color = 'red';

--- a/src/static/jscl-snippets.js
+++ b/src/static/jscl-snippets.js
@@ -1,0 +1,275 @@
+// Common Lisp Snippet Executor and Playground using JSCL
+// Loaded dynamically and runs completely client-side.
+
+let jsclLoading = false;
+let jsclLoaded = false;
+const jsclCallbacks = [];
+
+function ensureJSCL(callback) {
+  if (window.jscl) {
+    callback();
+    return;
+  }
+  jsclCallbacks.push(callback);
+  if (jsclLoading) return;
+  jsclLoading = true;
+
+  const script = document.createElement('script');
+  script.src = "https://cdn.jsdelivr.net/gh/jscl-project/jscl-project.github.io/jscl.js";
+  script.onload = () => {
+    jsclLoaded = true;
+    while (jsclCallbacks.length > 0) {
+      const cb = jsclCallbacks.shift();
+      cb();
+    }
+  };
+  script.onerror = () => {
+    // Try unpkg as a fallback CDN
+    const fallbackScript = document.createElement('script');
+    fallbackScript.src = "https://unpkg.com/jscl/dist/jscl.js";
+    fallbackScript.onload = () => {
+      jsclLoaded = true;
+      while (jsclCallbacks.length > 0) {
+        const cb = jsclCallbacks.shift();
+        cb();
+      }
+    };
+    fallbackScript.onerror = (err) => {
+      console.error("Failed to load JSCL from both CDNs:", err);
+      alert("Failed to load JSCL Common Lisp compiler. Please check your internet connection.");
+    };
+    document.head.appendChild(fallbackScript);
+  };
+  document.head.appendChild(script);
+}
+
+function initInlineSnippets() {
+  const blocks = document.querySelectorAll('pre.lisp-code-block:not(#playground-editor)');
+  blocks.forEach((block) => {
+    // Wrap the pre element
+    const container = document.createElement('div');
+    container.className = 'lisp-snippet-container';
+    container.style.margin = '1em 0';
+
+    block.parentNode.insertBefore(container, block);
+    container.appendChild(block);
+
+    // Create controls
+    const controls = document.createElement('div');
+    controls.className = 'lisp-snippet-controls';
+    controls.style.margin = '5px 0';
+    controls.style.display = 'flex';
+    controls.style.gap = '10px';
+
+    const runBtn = document.createElement('button');
+    runBtn.textContent = 'Run';
+    runBtn.className = 'lisp-btn lisp-btn-run';
+
+    const editBtn = document.createElement('button');
+    editBtn.textContent = 'Edit';
+    editBtn.className = 'lisp-btn lisp-btn-edit';
+
+    controls.appendChild(runBtn);
+    controls.appendChild(editBtn);
+    container.appendChild(controls);
+
+    // Create output panel
+    const outputPanel = document.createElement('pre');
+    outputPanel.className = 'lisp-output-panel';
+    outputPanel.style.display = 'none';
+    outputPanel.style.padding = '0.5em';
+    outputPanel.style.marginTop = '5px';
+    outputPanel.style.border = '1px dashed currentColor';
+    outputPanel.style.backgroundColor = 'rgba(128, 128, 128, 0.05)';
+    outputPanel.style.whiteSpace = 'pre-wrap';
+    outputPanel.style.wordBreak = 'break-all';
+    container.appendChild(outputPanel);
+
+    let isEditing = false;
+
+    editBtn.addEventListener('click', () => {
+      if (!isEditing) {
+        block.contentEditable = 'true';
+        block.spellcheck = false;
+        block.style.outline = '1px solid currentColor';
+        block.style.padding = '5px';
+        block.focus();
+        editBtn.textContent = 'View';
+        isEditing = true;
+      } else {
+        block.contentEditable = 'false';
+        block.style.outline = 'none';
+        block.style.padding = '';
+        editBtn.textContent = 'Edit';
+        isEditing = false;
+      }
+    });
+
+    runBtn.addEventListener('click', () => {
+      runBtn.disabled = true;
+      const originalText = runBtn.textContent;
+      runBtn.textContent = 'Running...';
+      outputPanel.style.display = 'block';
+      outputPanel.textContent = 'Initializing JSCL and executing...';
+
+      ensureJSCL(() => {
+        try {
+          const code = block.textContent;
+          const wrappedCode = `
+(let ((out (make-string-output-stream)))
+  (let ((*standard-output* out))
+    (let ((val (progn
+${code}
+    )))
+      (format nil "~A|==SEPARATOR==|~S" (get-output-stream-string out) val))))
+`;
+          const resRaw = window.jscl.evaluateString(wrappedCode);
+          let resStr = resRaw;
+          if (Array.isArray(resRaw)) {
+            resStr = resRaw.join('');
+          } else if (typeof resRaw !== 'string') {
+            resStr = String(resRaw);
+          }
+
+          let stdout = "";
+          let returnValue = "";
+          if (typeof resStr === 'string' && resStr.includes('|==SEPARATOR==|')) {
+            const parts = resStr.split('|==SEPARATOR==|');
+            stdout = parts[0];
+            returnValue = parts[1];
+          } else {
+            returnValue = String(resStr);
+          }
+
+          let displayResult = "";
+          if (stdout) {
+            displayResult += stdout;
+            if (!stdout.endsWith('\n')) {
+              displayResult += '\n';
+            }
+          }
+          displayResult += `=> ${returnValue}`;
+
+          outputPanel.textContent = displayResult;
+          outputPanel.style.color = '';
+        } catch (err) {
+          outputPanel.textContent = `Error: ${err.message || err}`;
+          outputPanel.style.color = 'red';
+        } finally {
+          runBtn.disabled = false;
+          runBtn.textContent = originalText;
+        }
+      });
+    });
+  });
+}
+
+function initPlayground() {
+  const editor = document.getElementById('playground-editor');
+  const runBtn = document.getElementById('playground-run');
+  const clearBtn = document.getElementById('playground-clear');
+  const examplesSelect = document.getElementById('playground-examples');
+  const outputPanel = document.getElementById('playground-output');
+
+  if (!editor || !runBtn || !clearBtn || !examplesSelect || !outputPanel) return;
+
+  const examples = {
+    hello: `(format t "Hello, World!~%")`,
+    fib: `(defun fib (n)
+  (if (< n 2)
+      n
+      (+ (fib (- n 1)) (fib (- n 2)))))
+
+(format t "Fibonacci of 10 is: ~a~%" (fib 10))`,
+    loop: `(loop for x from 1 to 5
+      do (format t "Square of ~d is ~d~%" x (* x x)))`,
+    clos: `(defclass person ()
+  ((name :accessor person-name :initarg :name)
+   (age :accessor person-age :initarg :age)))
+
+(defmethod introduce ((p person))
+  (format t "Hi, I am ~a and I am ~a years old.~%"
+          (person-name p)
+          (person-age p)))
+
+(let ((p (make-instance 'person :name "Alice" :age 30)))
+  (introduce p))`
+  };
+
+  examplesSelect.addEventListener('change', () => {
+    const key = examplesSelect.value;
+    const exampleData = document.getElementById('example-data-' + key);
+    if (exampleData) {
+      editor.innerHTML = exampleData.innerHTML;
+    } else {
+      editor.innerHTML = "";
+    }
+  });
+
+  clearBtn.addEventListener('click', () => {
+    outputPanel.textContent = '';
+    outputPanel.style.display = 'none';
+  });
+
+  runBtn.addEventListener('click', () => {
+    runBtn.disabled = true;
+    const originalText = runBtn.textContent;
+    runBtn.textContent = 'Running...';
+    outputPanel.style.display = 'block';
+    outputPanel.textContent = 'Initializing JSCL and executing...';
+
+    ensureJSCL(() => {
+      try {
+        const code = editor.textContent;
+        const wrappedCode = `
+(let ((out (make-string-output-stream)))
+  (let ((*standard-output* out))
+    (let ((val (progn
+${code}
+    )))
+      (format nil "~A|==SEPARATOR==|~S" (get-output-stream-string out) val))))
+`;
+        const resRaw = window.jscl.evaluateString(wrappedCode);
+        let resStr = resRaw;
+        if (Array.isArray(resRaw)) {
+          resStr = resRaw.join('');
+        } else if (typeof resRaw !== 'string') {
+          resStr = String(resRaw);
+        }
+
+        let stdout = "";
+        let returnValue = "";
+        if (typeof resStr === 'string' && resStr.includes('|==SEPARATOR==|')) {
+          const parts = resStr.split('|==SEPARATOR==|');
+          stdout = parts[0];
+          returnValue = parts[1];
+        } else {
+          returnValue = String(resStr);
+        }
+
+        let displayResult = "";
+        if (stdout) {
+          displayResult += stdout;
+          if (!stdout.endsWith('\n')) {
+            displayResult += '\n';
+          }
+        }
+        displayResult += `=> ${returnValue}`;
+
+        outputPanel.textContent = displayResult;
+        outputPanel.style.color = '';
+      } catch (err) {
+        outputPanel.textContent = `Error: ${err.message || err}`;
+        outputPanel.style.color = 'red';
+      } finally {
+        runBtn.disabled = false;
+        runBtn.textContent = originalText;
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initInlineSnippets();
+  initPlayground();
+});

--- a/src/static/styles/common.css
+++ b/src/static/styles/common.css
@@ -220,19 +220,5 @@ body.moderation .comment-preview {
   }
 }
 
-/* Syntax Highlighting for Lisp (Colorize output) */
-.lisp-code-block .string { color: #d14; }
-.lisp-code-block .comment { color: #998; font-style: italic; }
-.lisp-code-block .symbol { color: #008080; }
-.lisp-code-block .keyword { color: #000080; font-weight: bold; }
-.lisp-code-block .character { color: #099; }
-.lisp-code-block .special { color: #0086B3; }
-.lisp-code-block .paren1 { color: #aa0000; }
-.lisp-code-block .paren2 { color: #00aa00; }
-.lisp-code-block .paren3 { color: #0000aa; }
-.lisp-code-block .paren4 { color: #aaaa00; }
-.lisp-code-block .paren5 { color: #00aaaa; }
-.lisp-code-block .paren6 { color: #aa00aa; }
-
-/* In dark themes, these colors might need an override, but this provides a base */
+/* Syntax highlighting is now handled via separate syntax theme CSS files */
 

--- a/src/static/styles/common.css
+++ b/src/static/styles/common.css
@@ -184,3 +184,55 @@ body.moderation .comment-preview {
   background-color: #fafafa;
   border-left: 3px solid #ccc;
 }
+
+/* Lisp Interactive Snippets & Playground Styles */
+.lisp-btn {
+  padding: 4px 10px;
+  font-size: 0.85em;
+  font-family: inherit;
+  background: transparent;
+  color: inherit;
+  border: 1px solid currentColor;
+  cursor: pointer;
+  border-radius: 3px;
+  user-select: none;
+}
+
+.lisp-btn:hover {
+  background-color: rgba(128, 128, 128, 0.15);
+}
+
+.lisp-btn:active {
+  background-color: rgba(128, 128, 128, 0.3);
+}
+
+.lisp-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  #playground-editor {
+    width: 100% !important;
+  }
+  #playground-output {
+    width: 100% !important;
+  }
+}
+
+/* Syntax Highlighting for Lisp (Colorize output) */
+.lisp-code-block .string { color: #d14; }
+.lisp-code-block .comment { color: #998; font-style: italic; }
+.lisp-code-block .symbol { color: #008080; }
+.lisp-code-block .keyword { color: #000080; font-weight: bold; }
+.lisp-code-block .character { color: #099; }
+.lisp-code-block .special { color: #0086B3; }
+.lisp-code-block .paren1 { color: #aa0000; }
+.lisp-code-block .paren2 { color: #00aa00; }
+.lisp-code-block .paren3 { color: #0000aa; }
+.lisp-code-block .paren4 { color: #aaaa00; }
+.lisp-code-block .paren5 { color: #00aaaa; }
+.lisp-code-block .paren6 { color: #aa00aa; }
+
+/* In dark themes, these colors might need an override, but this provides a base */
+

--- a/src/static/styles/syntax/colorful.css
+++ b/src/static/styles/syntax/colorful.css
@@ -1,0 +1,13 @@
+/* Colorful Syntax Highlighting for Lisp (Colorize output) */
+.lisp-code-block .string { color: #d14; }
+.lisp-code-block .comment { color: #998; font-style: italic; }
+.lisp-code-block .symbol { color: #008080; }
+.lisp-code-block .keyword { color: #000080; font-weight: bold; }
+.lisp-code-block .character { color: #099; }
+.lisp-code-block .special { color: #0086B3; }
+.lisp-code-block .paren1 { color: #aa0000; }
+.lisp-code-block .paren2 { color: #00aa00; }
+.lisp-code-block .paren3 { color: #0000aa; }
+.lisp-code-block .paren4 { color: #aaaa00; }
+.lisp-code-block .paren5 { color: #00aaaa; }
+.lisp-code-block .paren6 { color: #aa00aa; }

--- a/src/static/styles/syntax/simple.css
+++ b/src/static/styles/syntax/simple.css
@@ -1,14 +1,19 @@
 /* Simple Syntax Highlighting for Lisp (Colorize output) */
-.lisp-code-block { color: #888888; } /* Default to gray for everything else */
-.lisp-code-block .string { color: #888888; }
-.lisp-code-block .comment { color: #888888; font-style: italic; }
-.lisp-code-block .symbol { color: #1e90ff; }
-.lisp-code-block .keyword { color: royalblue; font-weight: bold; }
-.lisp-code-block .character { color: #888888; }
-.lisp-code-block .special { color: #888888; }
-.lisp-code-block .paren1 { color: #888888; }
-.lisp-code-block .paren2 { color: #888888; }
-.lisp-code-block .paren3 { color: #888888; }
-.lisp-code-block .paren4 { color: #888888; }
-.lisp-code-block .paren5 { color: #888888; }
-.lisp-code-block .paren6 { color: #888888; }
+.lisp-code-block { 
+  background-color: #121214 !important; /* Rich dark background to improve contrast */
+  color: #b0b0b0 !important; /* Slightly lighter/clearer gray for base code */
+  padding: 10px !important;
+}
+
+.lisp-code-block .string { color: #b0b0b0; }
+.lisp-code-block .comment { color: #808080; font-style: italic; }
+.lisp-code-block .symbol { color: #1e90ff; font-style: normal !important; } /* Explicitly remove italic */
+.lisp-code-block .keyword { color: #5c87ff; font-weight: bold; } /* Vibrant royalblue for dark contrast */
+.lisp-code-block .character { color: #b0b0b0; }
+.lisp-code-block .special { color: #b0b0b0; }
+.lisp-code-block .paren1 { color: #b0b0b0; }
+.lisp-code-block .paren2 { color: #b0b0b0; }
+.lisp-code-block .paren3 { color: #b0b0b0; }
+.lisp-code-block .paren4 { color: #b0b0b0; }
+.lisp-code-block .paren5 { color: #b0b0b0; }
+.lisp-code-block .paren6 { color: #b0b0b0; }

--- a/src/static/styles/syntax/simple.css
+++ b/src/static/styles/syntax/simple.css
@@ -2,7 +2,7 @@
 .lisp-code-block { color: #888888; } /* Default to gray for everything else */
 .lisp-code-block .string { color: #888888; }
 .lisp-code-block .comment { color: #888888; font-style: italic; }
-.lisp-code-block .symbol { color: #888888; }
+.lisp-code-block .symbol { color: #1e90ff; }
 .lisp-code-block .keyword { color: royalblue; font-weight: bold; }
 .lisp-code-block .character { color: #888888; }
 .lisp-code-block .special { color: #888888; }

--- a/src/static/styles/syntax/simple.css
+++ b/src/static/styles/syntax/simple.css
@@ -1,0 +1,14 @@
+/* Simple Syntax Highlighting for Lisp (Colorize output) */
+.lisp-code-block { color: #888888; } /* Default to gray for everything else */
+.lisp-code-block .string { color: #888888; }
+.lisp-code-block .comment { color: #888888; font-style: italic; }
+.lisp-code-block .symbol { color: #888888; }
+.lisp-code-block .keyword { color: royalblue; font-weight: bold; }
+.lisp-code-block .character { color: #888888; }
+.lisp-code-block .special { color: #888888; }
+.lisp-code-block .paren1 { color: #888888; }
+.lisp-code-block .paren2 { color: #888888; }
+.lisp-code-block .paren3 { color: #888888; }
+.lisp-code-block .paren4 { color: #888888; }
+.lisp-code-block .paren5 { color: #888888; }
+.lisp-code-block .paren6 { color: #888888; }

--- a/src/static/styles/themes/matrix.css
+++ b/src/static/styles/themes/matrix.css
@@ -8,15 +8,15 @@ body {
   font-family: "Courier New", Courier, monospace;
   font-size: 100%;
   animation: pulse-glow 4s infinite alternate;
-  text-shadow: 0 0 5px #00ff41;
+  text-shadow: 0 0 3px #00ff41;
 }
 
 @keyframes pulse-glow {
   0% {
-    text-shadow: 0 0 2px #00ff41, 0 0 5px #00ff41;
+    text-shadow: 0 0 1px #00ff41, 0 0 3px #00ff41;
   }
   100% {
-    text-shadow: 0 0 4px #00ff41, 0 0 8px #008f11, 0 0 15px #003b00;
+    text-shadow: 0 0 2px #00ff41, 0 0 4px #008f11, 0 0 8px #003b00;
   }
 }
 
@@ -27,7 +27,7 @@ h1 {
   font-size: 2em;
   font-weight: bold;
   color: #d1ffdf;
-  text-shadow: 0 0 10px #00ff41, 0 0 20px #00ff41;
+  text-shadow: 0 0 5px #00ff41, 0 0 10px #00ff41;
   animation: glitch 1.5s ease-in-out infinite alternate;
 }
 
@@ -49,7 +49,7 @@ h2 {
   overflow-wrap: break-word;
   word-wrap: break-word;
   color: #a4ffbd;
-  text-shadow: 0 0 8px #00ff41;
+  text-shadow: 0 0 4px #00ff41;
 }
 
 /* Links */
@@ -83,12 +83,12 @@ div.newthread-form {
   padding: 1em;
   margin: 1em 2%;
   background-color: rgba(0, 59, 0, 0.2);
-  box-shadow: inset 0 0 10px #003b00;
+  box-shadow: inset 0 0 5px #003b00;
   transition: all 0.3s ease;
 }
 
 div.newthread-form:hover {
-  box-shadow: inset 0 0 20px #008f11;
+  box-shadow: inset 0 0 10px #008f11;
   border-color: #00ff41;
 }
 
@@ -121,7 +121,7 @@ pre.jump a {
 }
 
 pre.jump a:hover {
-  text-shadow: 0 0 15px #00ff41;
+  text-shadow: 0 0 8px #00ff41;
 }
 
 a, a:visited, a:active {
@@ -132,7 +132,7 @@ a, a:visited, a:active {
 }
 a:hover {
   color: #ffffff;
-  text-shadow: 0 0 10px #00ff41, 0 0 20px #00ff41;
+  text-shadow: 0 0 5px #00ff41, 0 0 10px #00ff41;
   text-decoration: underline dashed #00ff41;
 }
 a:target {
@@ -197,6 +197,7 @@ dd p {
 dd pre, dd code {
   font-size: 1em;
   font-family: monospace;
+  text-shadow: none !important;
 }
 
 dd pre {
@@ -231,7 +232,7 @@ del {
 del:active, del:hover {
   background-color: transparent;
   color: #00ff41;
-  text-shadow: 0 0 5px #00ff41;
+  text-shadow: 0 0 3px #00ff41;
 }
 
 /* thread list */
@@ -284,7 +285,7 @@ textarea, input[type=text] {
 textarea:focus, input[type=text]:focus {
     outline: none;
     border-color: #00ff41;
-    box-shadow: 0 0 10px rgba(0, 255, 65, 0.5);
+    box-shadow: 0 0 5px rgba(0, 255, 65, 0.5);
 }
 
 input[type=submit], button {
@@ -299,13 +300,13 @@ input[type=submit], button {
   cursor: pointer;
   text-transform: uppercase;
   transition: all 0.2s;
-  box-shadow: 0 0 5px #008f11;
+  box-shadow: 0 0 3px #008f11;
 }
 
 input[type=submit]:hover, button:hover {
   background-color: #00ff41;
   color: black;
-  box-shadow: 0 0 15px #00ff41;
+  box-shadow: 0 0 8px #00ff41;
 }
 
 input[type=submit]:active, button:active {
@@ -346,7 +347,7 @@ select {
 select:focus {
    outline: none;
    border-color: #00ff41;
-   box-shadow: 0 0 10px rgba(0, 255, 65, 0.4);
+   box-shadow: 0 0 5px rgba(0, 255, 65, 0.4);
 }
 
 
@@ -386,31 +387,32 @@ p.footer {
   background-color: #0d0d0d;
   color: #00ff41;
   border-left: 5px solid #00ff41;
-  box-shadow: 0 0 10px #003b00;
+  box-shadow: 0 0 5px #003b00;
   font-family: inherit;
 }
 
 .error-container .error-title {
   color: #ff3333;
-  text-shadow: 0 0 5px #ff3333;
+  text-shadow: 0 0 3px #ff3333;
 }
 
 .error-back-button {
   background-color: black;
   color: #00ff41;
   border: 1px solid #00ff41;
-  box-shadow: 0 0 5px #008f11;
+  box-shadow: 0 0 3px #008f11;
 }
 
 .error-back-button:hover {
   background-color: #00ff41;
   color: black;
-  box-shadow: 0 0 15px #00ff41;
+  box-shadow: 0 0 8px #00ff41;
 }
 
 /* Matrix Moderation Panel styling overrides */
 body.moderation .comment-preview {
   background-color: rgba(0, 59, 0, 0.2);
   border-left: 3px solid #008f11;
-  box-shadow: inset 0 0 5px #003b00;
+  box-shadow: inset 0 0 3px #003b00;
 }
+\n.lisp-code-block {\n  text-shadow: none !important;\n}

--- a/tests/integration/handlers.lisp
+++ b/tests/integration/handlers.lisp
@@ -120,6 +120,20 @@
       (is equal "text/html; charset=utf-8" (getf (second res) :content-type))
       (is equal t (not (null (search "This is a test post" (first (third res)))))))
 
+    ;; Test Global Playground GET /playground
+    (let* ((env (list :path-info "/playground" :request-method :get))
+           (res (cl-bbs/handlers:handle-request env)))
+      (is = 200 (first res))
+      (is equal "text/html; charset=utf-8" (getf (second res) :content-type))
+      (is equal t (not (null (search "Common Lisp Playground" (first (third res)))))))
+
+    ;; Test Board Playground GET /foo/playground
+    (let* ((env (list :path-info "/foo/playground" :request-method :get))
+           (res (cl-bbs/handlers:handle-request env)))
+      (is = 200 (first res))
+      (is equal "text/html; charset=utf-8" (getf (second res) :content-type))
+      (is equal t (not (null (search "Common Lisp Playground" (first (third res)))))))
+
     (when (probe-file thread-path)
       (delete-file thread-path))))
 

--- a/tests/unit/handlers.lisp
+++ b/tests/unit/handlers.lisp
@@ -126,7 +126,8 @@
       (true (some (lambda (file)
                        (let ((name (pathname-name file)))
                          (handler-case (and (parse-integer name)
-                                            (string= (cdr (assoc 'cl-bbs/models:headline (cl-bbs/storage:read-sexp-file file)))
+                                            (string= (cdr (assoc 'cl-bbs/models:headline
+                                                                 (cl-bbs/storage:read-sexp-file file)))
                                                      "Shame Test Thread"))
                            (error () nil))))
                      files))

--- a/tests/unit/views.lisp
+++ b/tests/unit/views.lisp
@@ -45,30 +45,21 @@
   ;; Executable Lisp code blocks
   (is equal (concatenate 'string
                          "<pre class=\"lisp-code-block\">"
-                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">"
-                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/f_format.htm\" class=\"symbol\">format</a> "
-                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/a_t.htm\" class=\"symbol\">t</a> "
-                         "<span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
       (cl-bbs/views::format-text "```lisp
 (format t \"Hello\")
 ```"))
   (is equal (concatenate 'string
                          "<pre class=\"lisp-code-block\">"
-                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">"
-                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/f_format.htm\" class=\"symbol\">format</a> "
-                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/a_t.htm\" class=\"symbol\">t</a> "
-                         "<span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
       (cl-bbs/views::format-text "```cl
 (format t \"Hello\")
 ```"))
   (is equal (concatenate 'string
                          "<pre class=\"lisp-code-block\">"
-                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">"
-                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/f_format.htm\" class=\"symbol\">format</a> "
-                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/a_t.htm\" class=\"symbol\">t</a> "
-                         "<span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
       (cl-bbs/views::format-text "```common-lisp
 (format t \"Hello\")

--- a/tests/unit/views.lisp
+++ b/tests/unit/views.lisp
@@ -45,24 +45,30 @@
   ;; Executable Lisp code blocks
   (is equal (concatenate 'string
                          "<pre class=\"lisp-code-block\">"
-                         "<span class=\"\"><span class=\"paren1\">"
-                         "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">"
+                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/f_format.htm\" class=\"symbol\">format</a> "
+                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/a_t.htm\" class=\"symbol\">t</a> "
+                         "<span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
       (cl-bbs/views::format-text "```lisp
 (format t \"Hello\")
 ```"))
   (is equal (concatenate 'string
                          "<pre class=\"lisp-code-block\">"
-                         "<span class=\"\"><span class=\"paren1\">"
-                         "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">"
+                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/f_format.htm\" class=\"symbol\">format</a> "
+                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/a_t.htm\" class=\"symbol\">t</a> "
+                         "<span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
       (cl-bbs/views::format-text "```cl
 (format t \"Hello\")
 ```"))
   (is equal (concatenate 'string
                          "<pre class=\"lisp-code-block\">"
-                         "<span class=\"\"><span class=\"paren1\">"
-                         "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">"
+                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/f_format.htm\" class=\"symbol\">format</a> "
+                         "<a href=\"http://www.lispworks.com/reference/HyperSpec/Body/a_t.htm\" class=\"symbol\">t</a> "
+                         "<span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
       (cl-bbs/views::format-text "```common-lisp
 (format t \"Hello\")

--- a/tests/unit/views.lisp
+++ b/tests/unit/views.lisp
@@ -43,15 +43,27 @@
 (list 1 2 3)
 ```"))
   ;; Executable Lisp code blocks
-  (is equal "<pre class=\"lisp-code-block\"><span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span></pre>"
+  (is equal (concatenate 'string
+                         "<pre class=\"lisp-code-block\">"
+                         "<span class=\"\"><span class=\"paren1\">"
+                         "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "</pre>")
       (cl-bbs/views::format-text "```lisp
 (format t \"Hello\")
 ```"))
-  (is equal "<pre class=\"lisp-code-block\"><span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span></pre>"
+  (is equal (concatenate 'string
+                         "<pre class=\"lisp-code-block\">"
+                         "<span class=\"\"><span class=\"paren1\">"
+                         "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "</pre>")
       (cl-bbs/views::format-text "```cl
 (format t \"Hello\")
 ```"))
-  (is equal "<pre class=\"lisp-code-block\"><span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span></pre>"
+  (is equal (concatenate 'string
+                         "<pre class=\"lisp-code-block\">"
+                         "<span class=\"\"><span class=\"paren1\">"
+                         "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "</pre>")
       (cl-bbs/views::format-text "```common-lisp
 (format t \"Hello\")
 ```")))

--- a/tests/unit/views.lisp
+++ b/tests/unit/views.lisp
@@ -41,4 +41,17 @@
       (cl-bbs/views::format-text "```
 ;;; code block
 (list 1 2 3)
+```"))
+  ;; Executable Lisp code blocks
+  (is equal "<pre class=\"lisp-code-block\"><span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span></pre>"
+      (cl-bbs/views::format-text "```lisp
+(format t \"Hello\")
+```"))
+  (is equal "<pre class=\"lisp-code-block\"><span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span></pre>"
+      (cl-bbs/views::format-text "```cl
+(format t \"Hello\")
+```"))
+  (is equal "<pre class=\"lisp-code-block\"><span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span></pre>"
+      (cl-bbs/views::format-text "```common-lisp
+(format t \"Hello\")
 ```")))

--- a/tests/unit/views.lisp
+++ b/tests/unit/views.lisp
@@ -45,21 +45,24 @@
   ;; Executable Lisp code blocks
   (is equal (concatenate 'string
                          "<pre class=\"lisp-code-block\">"
-                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "<span class=\"\"><span class=\"paren1\">"
+                         "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
       (cl-bbs/views::format-text "```lisp
 (format t \"Hello\")
 ```"))
   (is equal (concatenate 'string
                          "<pre class=\"lisp-code-block\">"
-                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "<span class=\"\"><span class=\"paren1\">"
+                         "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
       (cl-bbs/views::format-text "```cl
 (format t \"Hello\")
 ```"))
   (is equal (concatenate 'string
                          "<pre class=\"lisp-code-block\">"
-                         "<span class=\"\"><span class=\"paren1\">(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
+                         "<span class=\"\"><span class=\"paren1\">"
+                         "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
       (cl-bbs/views::format-text "```common-lisp
 (format t \"Hello\")


### PR DESCRIPTION
This PR introduces:

- Client-side execution of Common Lisp snippets via JSCL.
- An interactive `/playground` view with syntax-highlighted, executable Lisp examples.
- Backend HTML syntax highlighting for all Lisp snippets using the Quicklisp `colorize` library.
- Fixed the JSCL `evaluateString` array comma issue to ensure clean output streams.
- Cleaned up the Matrix theme by reducing glowing drop-shadows by 50% globally, and removing them entirely from source code blocks.
- Optimized the navigation bar layout (shortened names and moved the playground to `λ`).

# Showcase

<img width="1209" height="636" alt="image" src="https://github.com/user-attachments/assets/5c8695f7-2639-45df-ad4c-5bfaf54d1067" />


<img width="1863" height="977" alt="image" src="https://github.com/user-attachments/assets/b87dd6be-bfdc-4c4d-9101-841f19eb7552" />
