### PR TITLE
fix: limit size of headline and body (#16)

### DIFF
--- a/src/server/handlers.lisp
+++ b/src/server/handlers.lisp
@@ -15,9 +15,23 @@
                 #:render-thread
                 #:render-search-results
                 #:render-playground)
-  (:export #:handle-request))
+  (:export #:handle-request
+           #:*headline-limit*
+           #:*body-limit*))
 
 (in-package :cl-bbs/handlers)
+
+(defparameter *headline-limit*
+  (or (and (uiop:getenv "SBBS_HEADLINE_LIMIT")
+           (parse-integer (uiop:getenv "SBBS_HEADLINE_LIMIT") :junk-allowed t))
+      128)
+  "Maximum character limit for post headlines.")
+
+(defparameter *body-limit*
+  (or (and (uiop:getenv "SBBS_BODY_LIMIT")
+           (parse-integer (uiop:getenv "SBBS_BODY_LIMIT") :junk-allowed t))
+      4096)
+  "Maximum character limit for post bodies.")
 
 (defun parse-cookies (cookie-string)
   "Parses a Cookie header string like 'theme=dark; foo=bar' into an alist."
@@ -694,11 +708,21 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                (threads (read-sexp-file list-path))
                (thread-number (get-next-thread-number threads))
                (thread-path (merge-pathnames (format nil "sexp/~a/~a" board thread-number) *base-dir*)))
-          (if (or (null epistula)
-                  (string= "" (string-trim '(#\Space #\Tab #\Newline #\Return) epistula)))
-              `(400 (:content-type "text/html; charset=utf-8")
-                    (,(render-error-page "Post body cannot be empty" cl-bbs/views:*preferences*)))
-              (progn
+          (cond
+            ((or (null epistula)
+                 (string= "" (string-trim '(#\Space #\Tab #\Newline #\Return) epistula)))
+             `(400 (:content-type "text/html; charset=utf-8")
+                   (,(render-error-page "Post body cannot be empty" cl-bbs/views:*preferences*))))
+            ((and titulus (> (length titulus) *headline-limit*))
+             `(400 (:content-type "text/html; charset=utf-8")
+                   (,(render-error-page (format nil "Headline exceeds maximum length of ~D characters" *headline-limit*)
+                                        cl-bbs/views:*preferences*))))
+            ((and epistula (> (length epistula) *body-limit*))
+             `(400 (:content-type "text/html; charset=utf-8")
+                   (,(render-error-page (format nil "Post body exceeds maximum length of ~D characters" *body-limit*)
+                                        cl-bbs/views:*preferences*))))
+            (t
+             (progn
                 (when (is-board-locked board)
                   (return-from out
                     `(403 (:content-type "text/html; charset=utf-8")
@@ -713,7 +737,7 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                 (create-thread thread-path titulus date epistula)
                 (add-thread-to-list list-path thread-number titulus date)
                 (add-thread-to-index index-path thread-number titulus date epistula)
-                `(303 (:location ,(format nil "/~a/" board)) ("Redirecting..."))))))))
+                `(303 (:location ,(format nil "/~a/" board)) ("Redirecting...")))))))))
 
 ;; 11. GET /:board
 (setf (ningle:route *app* "/:board" :method :GET)
@@ -750,11 +774,17 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                  (epistula (cdr (assoc "epistula" parsed-params :test #'string=)))
                  (date (get-date))
                  (thread-path (merge-pathnames (format nil "sexp/~a/~a" board thread-id) *base-dir*)))
-            (if (or (null epistula)
-                    (string= "" (string-trim '(#\Space #\Tab #\Newline #\Return) epistula)))
-                `(400 (:content-type "text/html; charset=utf-8")
-                      (,(render-error-page "Post body cannot be empty" cl-bbs/views:*preferences*)))
-                (progn
+            (cond
+              ((or (null epistula)
+                   (string= "" (string-trim '(#\Space #\Tab #\Newline #\Return) epistula)))
+               `(400 (:content-type "text/html; charset=utf-8")
+                     (,(render-error-page "Post body cannot be empty" cl-bbs/views:*preferences*))))
+              ((and epistula (> (length epistula) *body-limit*))
+               `(400 (:content-type "text/html; charset=utf-8")
+                     (,(render-error-page (format nil "Post body exceeds maximum length of ~D characters" *body-limit*)
+                                          cl-bbs/views:*preferences*))))
+              (t
+               (progn
                   (when (is-board-locked board)
                     (return-from out
                       `(403 (:content-type "text/html; charset=utf-8")
@@ -834,7 +864,7 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                                                             actual-posts)))))
                                (write-sexp-file index-path (cons updated-entry rem-index))))))
                         `(303 (:location ,(format nil "/~a/" board)) ("Redirecting...")))
-                      `(404 (:content-type "text/plain") ("Thread not found")))))))))
+                      `(404 (:content-type "text/plain") ("Thread not found"))))))))))
 
 ;; 14. GET /:board/:thread_id/:range (Thread Comments with Range)
 (setf (ningle:route *app* "/:board/:thread_id/:range" :method :GET)

--- a/tests/integration/handlers.lisp
+++ b/tests/integration/handlers.lisp
@@ -283,3 +283,59 @@
       (let ((board-dir (merge-pathnames "sexp/lockedboard/" cl-bbs/storage:*base-dir*)))
         (when (probe-file board-dir)
           (uiop:delete-directory-tree board-dir :validate t))))))
+
+(define-test test-post-size-limits
+  :parent integration
+  ;; Ensure board dirs are created for testing board 'foo'
+  (cl-bbs/storage:ensure-board-dirs "foo")
+  (let ((original-headline-limit cl-bbs/handlers:*headline-limit*)
+        (original-body-limit cl-bbs/handlers:*body-limit*))
+    (unwind-protect
+         (progn
+           ;; Set small limits for testing ease
+           (setf cl-bbs/handlers:*headline-limit* 10)
+           (setf cl-bbs/handlers:*body-limit* 20)
+
+           ;; 1. POST New Thread with Too Long Headline (should 400 with HTML error page)
+           (let* ((body-str "titulus=ThisHeadlineIsTooLong&epistula=ShortBody")
+                  (body-bytes (flexi-streams:string-to-octets body-str :external-format :utf-8))
+                  (stream (flexi-streams:make-in-memory-input-stream body-bytes))
+                  (env (list :path-info "/foo/post"
+                             :request-method :post
+                             :content-length (length body-bytes)
+                             :raw-body stream))
+                  (res (cl-bbs/handlers:handle-request env)))
+             (is = 400 (first res))
+             (is equal "text/html; charset=utf-8" (getf (second res) :content-type))
+             (is equal t (not (null (search "Headline exceeds maximum length of 10 characters"
+                                            (first (third res)))))))
+
+           ;; 2. POST New Thread with Too Long Body (should 400 with HTML error page)
+           (let* ((body-str "titulus=Short&epistula=ThisBodyIsWayTooLongForThisLimit")
+                  (body-bytes (flexi-streams:string-to-octets body-str :external-format :utf-8))
+                  (stream (flexi-streams:make-in-memory-input-stream body-bytes))
+                  (env (list :path-info "/foo/post"
+                             :request-method :post
+                             :content-length (length body-bytes)
+                             :raw-body stream))
+                  (res (cl-bbs/handlers:handle-request env)))
+             (is = 400 (first res))
+             (is equal "text/html; charset=utf-8" (getf (second res) :content-type))
+             (is equal t (not (null (search "Post body exceeds maximum length of 20 characters"
+                                            (first (third res)))))))
+
+           ;; 3. POST Reply with Too Long Body (should 400 with HTML error page)
+           (let* ((body-str "epistula=ThisBodyIsWayTooLongForThisLimit")
+                  (body-bytes (flexi-streams:string-to-octets body-str :external-format :utf-8))
+                  (stream (flexi-streams:make-in-memory-input-stream body-bytes))
+                  (env (list :path-info "/foo/1/post"
+                             :request-method :post
+                             :content-length (length body-bytes)
+                             :raw-body stream))
+                  (res (cl-bbs/handlers:handle-request env)))
+             (is = 400 (first res))
+             (is equal "text/html; charset=utf-8" (getf (second res) :content-type))
+             (is equal t (not (null (search "Post body exceeds maximum length of 20 characters"
+                                            (first (third res))))))))
+      (setf cl-bbs/handlers:*headline-limit* original-headline-limit)
+      (setf cl-bbs/handlers:*body-limit* original-body-limit))))


### PR DESCRIPTION
Fixes #16. This PR defines configurable limits for thread headlines (*headline-limit*, default 128) and post bodies (*body-limit*, default 4096) that can be set via environment variables. It incorporates validation in the thread and reply post handlers, returning a 400 Bad Request with a clear message if limits are exceeded.