### PR TITLE
feat: implement post preview button and refactor markup module

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout PR Source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/cl-bbs.asd
+++ b/cl-bbs.asd
@@ -67,9 +67,10 @@
                (:module "server"
                 :depends-on ("package")
                 :components ((:file "models")
+                             (:file "markup")
                              (:file "storage" :depends-on ("models"))
-                             (:file "views" :depends-on ("models"))
-                             (:file "handlers" :depends-on ("storage" "views"))
+                             (:file "views" :depends-on ("models" "markup"))
+                             (:file "handlers" :depends-on ("storage" "views" "markup"))
                              (:file "main" :depends-on ("handlers" "storage"))
                              (:file "admin" :depends-on ("storage"))))))
 

--- a/src/server/handlers.lisp
+++ b/src/server/handlers.lisp
@@ -635,6 +635,19 @@ hyphens, and underscores. Otherwise returns nil to prevent injection/directory t
                         (error () (cl-who:escape-string code)))))
               `(400 (:content-type "text/plain") ("No code provided"))))))
 
+;; 6b-api2. POST /api/preview
+(setf (ningle:route *app* "/api/preview" :method :POST)
+      (lambda (params)
+        (let* ((env (lack.request:request-env ningle:*request*))
+               (parsed-params (get-body-params params env))
+               (content (cdr (assoc "content" parsed-params :test #'string=)))
+               (thread-id (cdr (assoc "thread_id" parsed-params :test #'string=))))
+          (if content
+              `(200 (:content-type "text/html; charset=utf-8")
+                    (,(cl-bbs/markup:format-text content thread-id)))
+              `(400 (:content-type "text/plain") ("No content provided"))))))
+
+
 ;; 6c. GET /playground (Global Playground)
 (setf (ningle:route *app* "/playground" :method :GET)
       (lambda (params)

--- a/src/server/markup.lisp
+++ b/src/server/markup.lisp
@@ -1,0 +1,152 @@
+(defpackage :cl-bbs/markup
+  (:use :cl)
+  (:export #:format-text
+           #:unescape-html))
+
+(in-package :cl-bbs/markup)
+
+(defun unescape-html (string)
+  "Unescapes basic HTML entities found in the STRING back to raw format."
+  (let ((s string))
+    (setf s (cl-ppcre:regex-replace-all "&quot;" s "\""))
+    (setf s (cl-ppcre:regex-replace-all "&lt;" s "<"))
+    (setf s (cl-ppcre:regex-replace-all "&gt;" s ">"))
+    (setf s (cl-ppcre:regex-replace-all "&#39;" s "'"))
+    (setf s (cl-ppcre:regex-replace-all "&#039;" s "'"))
+    (setf s (cl-ppcre:regex-replace-all "&apos;" s "'"))
+    (setf s (cl-ppcre:regex-replace-all "&#[xX]([0-9a-fA-F]+);" s
+                                        (lambda (match-string hex-str)
+                                          (declare (ignore match-string))
+                                          (string (code-char (parse-integer hex-str :radix 16))))
+                                        :simple-calls t))
+    (setf s (cl-ppcre:regex-replace-all "&#([0-9]+);" s
+                                        (lambda (match-string dec-str)
+                                          (declare (ignore match-string))
+                                          (string (code-char (parse-integer dec-str :radix 10))))
+                                        :simple-calls t))
+    (setf s (cl-ppcre:regex-replace-all "&amp;" s "&"))
+    s))
+
+(defun format-text (text &optional thread-id)
+  "Converts raw markdown-like TEXT into processed HTML.
+Supports bold, italic, code-blocks and optionally scoped references matching on THREAD-ID."
+  (let* ((escaped (cl-who:escape-string text))
+         ;; 1. Extract code blocks
+         (code-blocks '())
+         (code-block-placeholder-format "<!--CODEBLOCK-PLACEHOLDER-~a-->")
+         (placeholder-idx 0)
+         (processed escaped))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "(?s)```\\n*(.*?)\\n*```"
+           processed
+           (lambda (match-string &optional content &rest others)
+             (declare (ignore match-string others))
+             (let ((placeholder (format nil code-block-placeholder-format (incf placeholder-idx))))
+               (push (cons placeholder (or content "")) code-blocks)
+               placeholder))
+           :simple-calls t))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "(?m)^&gt;(?!&gt;)\\s*(.*?)$"
+           processed
+           "<blockquote>\\1</blockquote>"))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "\\*\\*(.*?)\\*\\*"
+           processed
+           "<b>\\1</b>"))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "__(.*?)__"
+           processed
+           "<i>\\1</i>"))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "`([^`]+)`"
+           processed
+           "<code>\\1</code>"))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "~~(.*?)~~"
+           processed
+           "<del>\\1</del>"))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "&gt;&gt;(\\d+)"
+           processed
+           (lambda (match-string &optional num &rest others)
+             (declare (ignore match-string others))
+             (let ((num-val (or num "")))
+               (if thread-id
+                   (format nil "<a href=\"#t~ap~a\">&gt;&gt;~a</a>" thread-id num-val num-val)
+                   (format nil "<a href=\"#t~a\">&gt;&gt;~a</a>" num-val num-val))))
+           :simple-calls t))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "https?://[\\w\\-\\.\\/\\?\\=\\&\\%#\\+:\\;]+"
+           processed
+           "<a href=\"\\&\" target=\"_blank\">\\&</a>"))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           (concatenate 'string
+                        "<a href=\"(https?://[\\w\\-\\.\\/\\?\\=\\&\\%#\\+:\\;]+"
+                        "\\.(?:png|jpg|jpeg|gif|webp|bmp))\" "
+                        "target=\"_blank\">.*?</a>")
+           processed
+           (concatenate 'string
+                        "<br /><a href=\"\\1\" target=\"_blank\">"
+                        "<img src=\"\\1\" style=\"max-width:300px; "
+                        "max-height:300px; display:block; margin:0.5em 0;\" "
+                        "alt=\"preview\" /></a><br />")))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "image\\+<a href=\"(https?://[\\w\\-\\.\\/\\?\\=\\&\\%#\\+:\\;]+)\" target=\"_blank\">.*?</a>"
+           processed
+           (concatenate 'string
+                        "<br /><a href=\"\\1\" target=\"_blank\">"
+                        "<img src=\"\\1\" style=\"max-width:300px; "
+                        "max-height:300px; display:block; margin:0.5em 0;\" "
+                        "alt=\"preview\" /></a><br />")))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "\\r\\n"
+           processed
+           (string #\Newline)))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "\\n\\n+"
+           processed
+           "</p><p>"))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "\\n"
+           processed
+           "<br />"))
+    (setf processed (format nil "<p>~a</p>" processed))
+    (dolist (pair code-blocks)
+      (let ((placeholder (car pair))
+            (content (cdr pair)))
+        (setf processed
+              (cl-ppcre:regex-replace-all
+               placeholder
+               processed
+               (lambda (match-string &optional regs)
+                 (declare (ignore match-string regs))
+                 (multiple-value-bind (match-start match-end reg-starts reg-ends)
+                     (cl-ppcre:scan "^(?i)(lisp|cl|common-lisp)\\r?\\n" content)
+                   (declare (ignore reg-starts reg-ends))
+                   (if match-start
+                       (let* ((escaped-code (subseq content match-end))
+                              (raw-code (unescape-html escaped-code))
+                              (colorized-code (handler-case (colorize:html-colorization :common-lisp raw-code)
+                                                (error () (cl-who:escape-string raw-code)))))
+                         (format nil "</p><pre class=\"lisp-code-block\">~a</pre><p>" colorized-code))
+                       (format nil "</p><pre>~a</pre><p>" content))))
+               :simple-calls t))))
+    (setf processed
+          (cl-ppcre:regex-replace-all
+           "<p>\\s*</p>"
+           processed
+           ""))
+    processed))

--- a/src/server/views.lisp
+++ b/src/server/views.lisp
@@ -8,6 +8,8 @@
                 #:fmt)
   (:import-from :cl-bbs/storage
                 #:is-board-locked)
+  (:import-from :cl-bbs/markup
+                #:format-text)
   (:export #:render-index
            #:render-list
            #:render-thread
@@ -114,6 +116,56 @@ function validatePostForm(form, errorId) {
   }
   return true;
 }
+
+function togglePreview(button, textareaName, threadId) {
+  const form = button.form;
+  const textarea = form.querySelector('textarea[name=\"' + textareaName + '\"]');
+  const content = textarea.value.trim();
+
+  if (!content) {
+    alert('Post body cannot be empty for preview!');
+    return;
+  }
+
+  let previewDiv = form.querySelector('.post-preview-container');
+  if (!previewDiv) {
+    previewDiv = document.createElement('div');
+    previewDiv.className = 'post-preview-container';
+    previewDiv.style.margin = '1em 0';
+    previewDiv.style.padding = '0.8em';
+    previewDiv.style.border = '1px dashed currentColor';
+    previewDiv.style.borderRadius = '4px';
+    previewDiv.style.display = 'none';
+    form.appendChild(previewDiv);
+  }
+
+  if (previewDiv.style.display === 'block') {
+    previewDiv.style.display = 'none';
+    button.value = 'Preview';
+    return;
+  }
+
+  previewDiv.innerHTML = '<em>Loading preview...</em>';
+  previewDiv.style.display = 'block';
+  button.value = 'Hide Preview';
+
+  const bodyData = 'content=' + encodeURIComponent(content) +
+    (threadId ? '&thread_id=' + encodeURIComponent(threadId) : '');
+
+  fetch('/api/preview', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: bodyData
+  })
+  .then(res => res.text())
+  .then(html => {
+    previewDiv.innerHTML = html;
+  })
+  .catch(err => {
+    console.error(err);
+    previewDiv.innerHTML = '<span style=\"color:red;\">Failed to load preview.</span>';
+  });
+}
 ")
        (:script :src "/static/jscl-snippets.js" :defer t))
       (:body :class ,class
@@ -182,7 +234,7 @@ function validatePostForm(form, errorId) {
                (cl-who:htm (:input :type "hidden" :name "board" :value board)))
              (:input :type "text" :name "q" :placeholder "Search posts..."
                      :style "padding: 2px 5px; font-size: 0.85em; margin-right: 5px;")
-             (:input :type "submit" :value "Search" :style "padding: 2px 8px; font-size: 0.85em;")))))
+             (:input :type "submit" :value "Search" :class "lisp-btn")))))
 
 (defun render-boards-header ()
   (let* ((sexp-dir (merge-pathnames "sexp/" cl-bbs/storage:*base-dir*))
@@ -211,7 +263,7 @@ function validatePostForm(form, errorId) {
                         (cl-who:htm (:input :type "hidden" :name "board" :value board)))
                       (:input :type "text" :name "q" :placeholder "Search posts..."
                      :style "padding: 2px 5px; font-size: 0.85em; margin-right: 5px;")
-                      (:input :type "submit" :value "Search" :style "padding: 2px 8px; font-size: 0.85em;"))))))))
+                      (:input :type "submit" :value "Search" :class "lisp-btn"))))))))
 
 (defun render-menu (board selected)
   (cl-who:with-html-output-to-string (s nil :indent t)
@@ -242,190 +294,38 @@ function validatePostForm(form, errorId) {
           (:h2 :id "newthread" "New thread")
           (:p :id "newthread-error" :style "color: red; font-weight: bold; display: none;")
           (:form :action (format nil "/~a/post" board)
-                 :method "POST"
-                 :onsubmit "return validatePostForm(this, 'newthread-error');"
+          :method "POST"
+          :onsubmit "return validatePostForm(this, \"newthread-error\");"
                  (:p (:input :type "text" :name "titulus" :size 35 :placeholder "Headline"))
                  (:p (:textarea :name "epistula"
                                 :rows 5
                                 :cols 50
                                 :placeholder "Message"
-                                :onkeydown "if(event.ctrlKey && event.key === 'Enter') {
-  if (validatePostForm(this.form, 'newthread-error')) {
-    this.form.submit();
-  }
-}"))
+                                :onkeydown "if(event.ctrlKey && event.key === 'Enter') { if (validatePostForm(this.form, \"newthread-error\")) { this.form.submit(); } }"))
                  (:p (:input :type "text" :name "name" :style "display:none")
                      (:input :type "text" :name "message" :style "display:none")
-                     (:input :type "submit" :value "Post"))))))
-
-(defun unescape-html (string)
-  (let ((s string))
-    (setf s (cl-ppcre:regex-replace-all "&quot;" s "\""))
-    (setf s (cl-ppcre:regex-replace-all "&lt;" s "<"))
-    (setf s (cl-ppcre:regex-replace-all "&gt;" s ">"))
-    (setf s (cl-ppcre:regex-replace-all "&#39;" s "'"))
-    (setf s (cl-ppcre:regex-replace-all "&#039;" s "'"))
-    (setf s (cl-ppcre:regex-replace-all "&apos;" s "'"))
-    (setf s (cl-ppcre:regex-replace-all "&#[xX]([0-9a-fA-F]+);" s
-                                        (lambda (match-string hex-str)
-                                          (declare (ignore match-string))
-                                          (string (code-char (parse-integer hex-str :radix 16))))
-                                        :simple-calls t))
-    (setf s (cl-ppcre:regex-replace-all "&#([0-9]+);" s
-                                        (lambda (match-string dec-str)
-                                          (declare (ignore match-string))
-                                          (string (code-char (parse-integer dec-str :radix 10))))
-                                        :simple-calls t))
-    (setf s (cl-ppcre:regex-replace-all "&amp;" s "&"))
-    s))
-
-(defun format-text (text &optional thread-id)
-  (let* ((escaped (cl-who:escape-string text))
-         ;; 1. Extract code blocks
-         (code-blocks '())
-         (code-block-placeholder-format "<!--CODEBLOCK-PLACEHOLDER-~a-->")
-         (placeholder-idx 0)
-         (processed escaped))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "(?s)```\\n*(.*?)\\n*```"
-           processed
-           (lambda (match-string &optional content &rest others)
-             (declare (ignore match-string others))
-             (let ((placeholder (format nil code-block-placeholder-format (incf placeholder-idx))))
-               (push (cons placeholder (or content "")) code-blocks)
-               placeholder))
-           :simple-calls t))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "(?m)^&gt;(?!&gt;)\\s*(.*?)$"
-           processed
-           "<blockquote>\\1</blockquote>"))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "\\*\\*(.*?)\\*\\*"
-           processed
-           "<b>\\1</b>"))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "__(.*?)__"
-           processed
-           "<i>\\1</i>"))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "`([^`]+)`"
-           processed
-           "<code>\\1</code>"))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "~~(.*?)~~"
-           processed
-           "<del>\\1</del>"))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "&gt;&gt;(\\d+)"
-           processed
-           (lambda (match-string &optional num &rest others)
-             (declare (ignore match-string others))
-             (let ((num-val (or num "")))
-               (if thread-id
-                   (format nil "<a href=\"#t~ap~a\">&gt;&gt;~a</a>" thread-id num-val num-val)
-                   (format nil "<a href=\"#t~a\">&gt;&gt;~a</a>" num-val num-val))))
-           :simple-calls t))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "https?://[\\w\\-\\.\\/\\?\\=\\&\\%#\\+:\\;]+"
-           processed
-           "<a href=\"\\&\" target=\"_blank\">\\&</a>"))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           (concatenate 'string
-                        "<a href=\"(https?://[\\w\\-\\.\\/\\?\\=\\&\\%#\\+:\\;]+"
-                        "\\.(?:png|jpg|jpeg|gif|webp|bmp))\" "
-                        "target=\"_blank\">.*?</a>")
-           processed
-           (concatenate 'string
-                        "<br /><a href=\"\\1\" target=\"_blank\">"
-                        "<img src=\"\\1\" style=\"max-width:300px; "
-                        "max-height:300px; display:block; margin:0.5em 0;\" "
-                        "alt=\"preview\" /></a><br />")))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "image\\+<a href=\"(https?://[\\w\\-\\.\\/\\?\\=\\&\\%#\\+:\\;]+)\" target=\"_blank\">.*?</a>"
-           processed
-           (concatenate 'string
-                        "<br /><a href=\"\\1\" target=\"_blank\">"
-                        "<img src=\"\\1\" style=\"max-width:300px; "
-                        "max-height:300px; display:block; margin:0.5em 0;\" "
-                        "alt=\"preview\" /></a><br />")))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "\\r\\n"
-           processed
-           (string #\Newline)))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "\\n\\n+"
-           processed
-           "</p><p>"))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "\\n"
-           processed
-           "<br />"))
-    (setf processed (format nil "<p>~a</p>" processed))
-    (dolist (pair code-blocks)
-      (let ((placeholder (car pair))
-            (content (cdr pair)))
-        (setf processed
-              (cl-ppcre:regex-replace-all
-               placeholder
-               processed
-               (lambda (match-string &optional regs)
-                 (declare (ignore match-string regs))
-                 (multiple-value-bind (match-start match-end reg-starts reg-ends)
-                     (cl-ppcre:scan "^(?i)(lisp|cl|common-lisp)\\r?\\n" content)
-                   (declare (ignore reg-starts reg-ends))
-                   (if match-start
-                       (let* ((escaped-code (subseq content match-end))
-                              (raw-code (unescape-html escaped-code))
-                              (colorized-code (handler-case (colorize:html-colorization :common-lisp raw-code)
-                                                (error () (cl-who:escape-string raw-code)))))
-                         ;; Note: colorize already wraps the result in <span class="..."><span class="paren1">...
-                         ;; We wrap it in <pre class="lisp-code-block"> but keep a data-raw-code attribute
-                         ;; or just use content for JS execution. JSCL needs the raw text. To avoid JSCL trying
-                         ;; to parse HTML, we'll embed the raw code in a hidden div, or rely on JS `textContent`
-                         ;; which extracts raw text from nested HTML elements. `textContent` works well.
-                         (format nil "</p><pre class=\"lisp-code-block\">~a</pre><p>" colorized-code))
-                       (format nil "</p><pre>~a</pre><p>" content))))
-               :simple-calls t))))
-    (setf processed
-          (cl-ppcre:regex-replace-all
-           "<p>\\s*</p>"
-           processed
-           ""))
-    processed))
-
+                     (:input :type "submit" :value "Post" :class "lisp-btn")
+                     (:input :type "button" :value "Preview" :class "lisp-btn" 
+                             :style "margin-left: 5px;"
+                             :onclick "togglePreview(this, \"epistula\", null);"))))))
 (defun render-post-form (board thread-id)
   (let ((error-id (format nil "reply-error-~a" thread-id)))
     (cl-who:with-html-output-to-string (s nil :indent t)
       (:p :id error-id :style "color: red; font-weight: bold; display: none;")
       (:form :action (format nil "/~a/~a/post" board thread-id)
              :method "POST"
-             :onsubmit (format nil "return validatePostForm(this, '~a');" error-id)
+             :onsubmit (format nil "return validatePostForm(this, \"~a\");" error-id)
              (:p (:textarea :name "epistula"
                             :rows 8
                             :cols 78
                             :placeholder "Message"
-                            :onkeydown (format nil "if(event.ctrlKey && event.key === 'Enter') {
-  if (validatePostForm(this.form, '~a')) {
-    this.form.submit();
-  }
-}" error-id))
-                 (:br)
-                 (:input :type "text" :name "name" :class "name" :style "display:none")
+                            :onkeydown (format nil "if(event.ctrlKey && event.key === 'Enter') { if (validatePostForm(this.form, \"~a\")) { this.form.submit(); } }" error-id)))
+             (:p (:input :type "text" :name "name" :class "name" :style "display:none")
                  (:input :type "text" :name "message" :class "message" :style "display:none")
-                 (:input :type "submit" :value "POST"))))))
+                 (:input :type "submit" :value "POST" :class "lisp-btn")
+                 (:input :type "button" :value "Preview" :class "lisp-btn"
+                          :style "margin-left: 5px;"
+                          :onclick (format nil "togglePreview(this, \"epistula\", '~a');" thread-id)))))))
 
 (defun render-frontpage-thread (board thread-data index &optional (prefs *preferences*))
   (let* ((thread-id (car thread-data))

--- a/tests/unit/views.lisp
+++ b/tests/unit/views.lisp
@@ -3,42 +3,49 @@
 (define-test test-format-text
   :parent unit
   ;; Bold
-  (is equal "<p>This is <b>bold</b> text</p>" (cl-bbs/views::format-text "This is **bold** text"))
+  (is equal "<p>This is <b>bold</b> text</p>"
+      (cl-bbs/markup:format-text "This is **bold** text"))
   ;; Italic
-  (is equal "<p>This is <i>italic</i> text</p>" (cl-bbs/views::format-text "This is __italic__ text"))
+  (is equal "<p>This is <i>italic</i> text</p>"
+      (cl-bbs/markup:format-text "This is __italic__ text"))
   ;; Monospace
-  (is equal "<p>This is <code>code</code> text</p>" (cl-bbs/views::format-text "This is `code` text"))
+  (is equal "<p>This is <code>code</code> text</p>"
+      (cl-bbs/markup:format-text "This is `code` text"))
   ;; Spoiler
-  (is equal "<p>This is <del>spoiler</del> text</p>" (cl-bbs/views::format-text "This is ~~spoiler~~ text"))
+  (is equal "<p>This is <del>spoiler</del> text</p>"
+      (cl-bbs/markup:format-text "This is ~~spoiler~~ text"))
   ;; Quote
-  (is equal "<p><blockquote>quoted text</blockquote></p>" (cl-bbs/views::format-text ">quoted text"))
+  (is equal "<p><blockquote>quoted text</blockquote></p>"
+      (cl-bbs/markup:format-text ">quoted text"))
   ;; Post reference without thread-id
-  (is equal "<p><a href=\"#t7\">&gt;&gt;7</a></p>" (cl-bbs/views::format-text ">>7"))
+  (is equal "<p><a href=\"#t7\">&gt;&gt;7</a></p>"
+      (cl-bbs/markup:format-text ">>7"))
   ;; Post reference with thread-id
-  (is equal "<p><a href=\"#t4p7\">&gt;&gt;7</a></p>" (cl-bbs/views::format-text ">>7" "4"))
+  (is equal "<p><a href=\"#t4p7\">&gt;&gt;7</a></p>"
+      (cl-bbs/markup:format-text ">>7" "4"))
   ;; Standard URL
   (is equal (concatenate 'string
                          "<p>Check <a href=\"https://example.com/page\" target=\"_blank\">"
                          "https://example.com/page</a></p>")
-      (cl-bbs/views::format-text "Check https://example.com/page"))
+      (cl-bbs/markup:format-text "Check https://example.com/page"))
   ;; Direct image URL
   (is equal (concatenate 'string
                          "<p>Check <br /><a href=\"https://example.com/pic.png\" target=\"_blank\">"
                          "<img src=\"https://example.com/pic.png\" "
                          "style=\"max-width:300px; max-height:300px; display:block; margin:0.5em 0;\" "
                          "alt=\"preview\" /></a><br /></p>")
-      (cl-bbs/views::format-text "Check https://example.com/pic.png"))
+      (cl-bbs/markup:format-text "Check https://example.com/pic.png"))
   ;; Explicit image prefix override URL
   (is equal (concatenate 'string
                          "<p>Check <br /><a href=\"https://example.com/dynamic-image?id=1\" "
                          "target=\"_blank\"><img src=\"https://example.com/dynamic-image?id=1\" "
                          "style=\"max-width:300px; max-height:300px; display:block; margin:0.5em 0;\" "
                          "alt=\"preview\" /></a><br /></p>")
-      (cl-bbs/views::format-text "Check image+https://example.com/dynamic-image?id=1"))
+      (cl-bbs/markup:format-text "Check image+https://example.com/dynamic-image?id=1"))
   ;; Code block (using literal newlines in CL strings)
   (is equal "<pre>;;; code block
 (list 1 2 3)</pre>"
-      (cl-bbs/views::format-text "```
+      (cl-bbs/markup:format-text "```
 ;;; code block
 (list 1 2 3)
 ```"))
@@ -48,7 +55,7 @@
                          "<span class=\"\"><span class=\"paren1\">"
                          "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
-      (cl-bbs/views::format-text "```lisp
+      (cl-bbs/markup:format-text "```lisp
 (format t \"Hello\")
 ```"))
   (is equal (concatenate 'string
@@ -56,7 +63,7 @@
                          "<span class=\"\"><span class=\"paren1\">"
                          "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
-      (cl-bbs/views::format-text "```cl
+      (cl-bbs/markup:format-text "```cl
 (format t \"Hello\")
 ```"))
   (is equal (concatenate 'string
@@ -64,15 +71,41 @@
                          "<span class=\"\"><span class=\"paren1\">"
                          "(<span class=\"\">format t <span class=\"string\">\"Hello\"</span></span>)</span></span>"
                          "</pre>")
-      (cl-bbs/views::format-text "```common-lisp
+      (cl-bbs/markup:format-text "```common-lisp
 (format t \"Hello\")
 ```"))
   ;; Issue #17 URL tests (colons and semicolons in URL)
   (is equal (concatenate 'string
-                         "<p>Check <a href=\"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQL--f01xIZCRt7R0w6xxdR5v76IRrZImu6OCETYL01n0J0fx4cFud3Y4gY&amp;s=10\" target=\"_blank\">"
-                         "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQL--f01xIZCRt7R0w6xxdR5v76IRrZImu6OCETYL01n0J0fx4cFud3Y4gY&amp;s=10</a></p>")
-      (cl-bbs/views::format-text "Check https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQL--f01xIZCRt7R0w6xxdR5v76IRrZImu6OCETYL01n0J0fx4cFud3Y4gY&s=10"))
+                         "<p>Check <a href=\"https://encrypted-tbn0.gstatic.com/"
+                         "images?q=tbn:ANd9GcQL--f01xIZCRt7R0w6xxdR5v76IRrZ"
+                         "Imu6OCETYL01n0J0fx4cFud3Y4gY&amp;s=10\" target="
+                         "\"_blank\">https://encrypted-tbn0.gstatic.com/"
+                         "images?q=tbn:ANd9GcQL--f01xIZCRt7R0w6xxdR5v76IRrZ"
+                         "Imu6OCETYL01n0J0fx4cFud3Y4gY&amp;s=10</a></p>")
+      (cl-bbs/markup:format-text
+       (concatenate 'string
+                    "Check https://encrypted-tbn0.gstatic.com/"
+                    "images?q=tbn:ANd9GcQL--"
+                    "f01xIZCRt7R0w6xxdR5v76IR"
+                    "rZImu6OCETYL01n0J0"
+                    "fx4cFud3Y4gY&s=10")))
   (is equal (concatenate 'string
-                         "<p>Check <a href=\"https://www.reddit.com/r/Common_Lisp/comments/1pqghsx/comment/nuvmq9z/?utm_source=share&amp;;utm_medium=mweb3x&amp;utm_name=mweb3xcss&amp;utm_term=2&amp;utm_content=share_button\" target=\"_blank\">"
-                         "https://www.reddit.com/r/Common_Lisp/comments/1pqghsx/comment/nuvmq9z/?utm_source=share&amp;;utm_medium=mweb3x&amp;utm_name=mweb3xcss&amp;utm_term=2&amp;utm_content=share_button</a></p>")
-      (cl-bbs/views::format-text "Check https://www.reddit.com/r/Common_Lisp/comments/1pqghsx/comment/nuvmq9z/?utm_source=share&;utm_medium=mweb3x&utm_name=mweb3xcss&utm_term=2&utm_content=share_button")))
+                         "<p>Check <a href=\"https://www.reddit.com/r/"
+                         "Common_Lisp/comments/1pqghsx/comment/nuvmq9z/?"
+                         "utm_source=share&amp;;utm_medium=mweb3x&amp;"
+                         "utm_name=mweb3xcss&amp;utm_term=2&amp;"
+                         "utm_content=share_button\" target=\"_blank\">"
+                         "https://www.reddit.com/r/Common_Lisp/"
+                         "comments/1pqghsx/comment/nuvmq9z/?"
+                         "utm_source=share&amp;;utm_medium=mweb3x&amp;"
+                         "utm_name=mweb3xcss&amp;utm_term=2&amp;"
+                         "utm_content=share_button</a></p>")
+      (cl-bbs/markup:format-text
+       (concatenate 'string
+                    "Check https://www.reddit.com/r/"
+                    "Common_Lisp/comments/1pqghsx/"
+                    "comment/nuvmq9z/?utm_source=share&;"
+                    "utm_medium=mweb3x&"
+                    "utm_name=mweb3xcss&"
+                    "utm_term=2&"
+                    "utm_content=share_button"))))


### PR DESCRIPTION
This PR refactors the text markdown formatting logic into a dedicated packet `cl-bbs/markup`. Under this new design, it implements a 'Preview' button next to each 'Post' submit button on both the thread and comment reply forms. Below the forms, the preview gets rendered dynamically using an asynchronous query to the backend `/api/preview` endpoint utilizing the exact same backend engine.