### PR TITLE
fix: deploy-qa commit hash

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout PR Source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Without this the on going PR commits was deploying the master branch !?